### PR TITLE
feat: add CODEOWNERS file to replace Dependabot reviewers configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS file for TrueNAS Manager Flutter app
+# This file defines who is responsible for code review in different parts of the repository
+# For more information, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @cedricziel

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "cedricziel"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
- Adds CODEOWNERS file to define code review responsibilities
- Removes deprecated Dependabot reviewers configuration
- Prepares for GitHub's deprecation of Dependabot reviewers on May 20, 2025

## Context
GitHub is removing the Dependabot reviewers configuration option and recommending the use of CODEOWNERS files instead. This provides a more consistent way to assign pull request reviewers and consolidates review assignment into a single configuration file.

## Changes
- Created `.github/CODEOWNERS` file with global owner configuration (`@cedricziel`)
- Removed `reviewers` section from `.github/dependabot.yml`

## Test Plan
- [x] CODEOWNERS file follows GitHub syntax
- [x] Dependabot configuration remains valid without reviewers section
- [x] All code paths have an assigned owner (global owner covers everything)

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a code ownership file specifying the default code owner for the repository.
  * Updated Dependabot configuration by removing the default reviewer for automated dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->