### PR TITLE
feat: add configurable default server for automatic selection on app launch

### DIFF
--- a/lib/models/nas_server.dart
+++ b/lib/models/nas_server.dart
@@ -15,6 +15,7 @@ class NasServer extends Equatable {
   final bool allowUntrustedCertificates;
   final DateTime? lastConnected;
   final bool isActive;
+  final bool isDefault;
 
   const NasServer({
     required this.id,
@@ -29,6 +30,7 @@ class NasServer extends Equatable {
     this.allowUntrustedCertificates = false,
     this.lastConnected,
     this.isActive = true,
+    this.isDefault = false,
   });
 
   factory NasServer.create({
@@ -41,6 +43,7 @@ class NasServer extends Equatable {
     required String password,
     bool useHttps = true,
     bool allowUntrustedCertificates = false,
+    bool isDefault = false,
   }) {
     return NasServer(
       id: const Uuid().v4(),
@@ -53,6 +56,7 @@ class NasServer extends Equatable {
       password: password,
       useHttps: useHttps,
       allowUntrustedCertificates: allowUntrustedCertificates,
+      isDefault: isDefault,
     );
   }
 
@@ -69,6 +73,7 @@ class NasServer extends Equatable {
     bool? allowUntrustedCertificates,
     DateTime? lastConnected,
     bool? isActive,
+    bool? isDefault,
     // Special flag to explicitly clear localUrl
     bool clearLocalUrl = false,
     // Special flag to explicitly clear port
@@ -88,6 +93,7 @@ class NasServer extends Equatable {
           allowUntrustedCertificates ?? this.allowUntrustedCertificates,
       lastConnected: lastConnected ?? this.lastConnected,
       isActive: isActive ?? this.isActive,
+      isDefault: isDefault ?? this.isDefault,
     );
   }
 
@@ -131,5 +137,6 @@ class NasServer extends Equatable {
     allowUntrustedCertificates,
     lastConnected,
     isActive,
+    isDefault,
   ];
 }

--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -35,6 +35,29 @@ class ServerProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> loadServersAndAutoSelect() async {
+    await loadServers();
+    await _autoSelectServer();
+  }
+
+  Future<void> _autoSelectServer() async {
+    if (_selectedServer != null) {
+      return; // Don't auto-select if server already selected
+    }
+
+    // First check for default server
+    final defaultServer = await _database.getDefaultServer();
+    if (defaultServer != null) {
+      selectServer(defaultServer);
+      return;
+    }
+
+    // If no default server and only one server exists, auto-select it
+    if (_servers.length == 1) {
+      selectServer(_servers.first);
+    }
+  }
+
   Future<void> addServer(models.NasServer server) async {
     await _database.insertServer(server);
     await loadServers();
@@ -149,6 +172,24 @@ class ServerProvider extends ChangeNotifier {
       return result;
     } catch (e) {
       return false;
+    }
+  }
+
+  Future<void> setDefaultServer(String serverId) async {
+    await _database.setDefaultServer(serverId);
+    await loadServers();
+  }
+
+  Future<void> clearDefaultServer() async {
+    await _database.clearDefaultServer();
+    await loadServers();
+  }
+
+  models.NasServer? get defaultServer {
+    try {
+      return _servers.firstWhere((server) => server.isDefault);
+    } catch (e) {
+      return null;
     }
   }
 

--- a/lib/screens/edit_server_screen.dart
+++ b/lib/screens/edit_server_screen.dart
@@ -23,6 +23,7 @@ class _EditServerScreenState extends State<EditServerScreen> {
   late TextEditingController _wifiSsidController;
   late bool _useHttps;
   late bool _allowUntrustedCertificates;
+  late bool _isDefault;
   bool _isTestingConnection = false;
   String? _connectionTestResult;
   late List<String> _trustedWifiSsids;
@@ -49,6 +50,7 @@ class _EditServerScreenState extends State<EditServerScreen> {
     _wifiSsidController = TextEditingController();
     _useHttps = widget.server.useHttps;
     _allowUntrustedCertificates = widget.server.allowUntrustedCertificates;
+    _isDefault = widget.server.isDefault;
     _trustedWifiSsids = List.from(widget.server.trustedWifiSsids);
   }
 
@@ -223,11 +225,19 @@ class _EditServerScreenState extends State<EditServerScreen> {
       password: _passwordController.text,
       useHttps: _useHttps,
       allowUntrustedCertificates: _allowUntrustedCertificates,
+      isDefault: _isDefault,
     );
 
     if (_localUrlController.text.isEmpty && widget.server.localUrl != null) {}
 
-    await context.read<ServerProvider>().updateServer(updatedServer);
+    // If setting this server as default, handle the database update
+    if (_isDefault && !widget.server.isDefault) {
+      await context.read<ServerProvider>().setDefaultServer(widget.server.id);
+    } else if (!_isDefault && widget.server.isDefault) {
+      await context.read<ServerProvider>().clearDefaultServer();
+    } else {
+      await context.read<ServerProvider>().updateServer(updatedServer);
+    }
 
     if (mounted) {
       Navigator.pop(context, true); // Return true to indicate changes were made
@@ -409,6 +419,17 @@ class _EditServerScreenState extends State<EditServerScreen> {
                     onChanged: (value) {
                       setState(() {
                         _allowUntrustedCertificates = value;
+                      });
+                    },
+                  ),
+                ),
+                CupertinoFormRow(
+                  prefix: const Text('Set as Default Server'),
+                  child: CupertinoSwitch(
+                    value: _isDefault,
+                    onChanged: (value) {
+                      setState(() {
+                        _isDefault = value;
                       });
                     },
                   ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,8 +6,36 @@ import 'package:truenas_manager/screens/server_detail_screen.dart';
 import 'package:truenas_manager/screens/settings_screen.dart';
 import 'package:truenas_manager/widgets/server_list_tile.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final serverProvider = Provider.of<ServerProvider>(
+        context,
+        listen: false,
+      );
+      serverProvider.loadServersAndAutoSelect().then((_) {
+        // If a server was auto-selected, navigate to it
+        if (mounted && serverProvider.selectedServer != null) {
+          Navigator.push(
+            context,
+            CupertinoPageRoute(
+              builder: (context) =>
+                  ServerDetailScreen(server: serverProvider.selectedServer!),
+            ),
+          );
+        }
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -20,6 +20,7 @@ class NasServers extends Table {
       boolean().withDefault(const Constant(false))();
   DateTimeColumn get lastConnected => dateTime().nullable()();
   BoolColumn get isActive => boolean().withDefault(const Constant(true))();
+  BoolColumn get isDefault => boolean().withDefault(const Constant(false))();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -33,10 +34,19 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   @override
-  MigrationStrategy get migration => MigrationStrategy();
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (m) async {
+      await m.createAll();
+    },
+    onUpgrade: (m, from, to) async {
+      if (from < 2) {
+        await m.addColumn(nasServers, nasServers.isDefault);
+      }
+    },
+  );
 
   Future<List<models.NasServer>> getAllServers() async {
     final query = select(nasServers);
@@ -70,6 +80,7 @@ class AppDatabase extends _$AppDatabase {
         allowUntrustedCertificates: Value(server.allowUntrustedCertificates),
         lastConnected: Value(server.lastConnected),
         isActive: Value(server.isActive),
+        isDefault: Value(server.isDefault),
       ),
     );
   }
@@ -88,6 +99,7 @@ class AppDatabase extends _$AppDatabase {
         allowUntrustedCertificates: Value(server.allowUntrustedCertificates),
         lastConnected: Value(server.lastConnected),
         isActive: Value(server.isActive),
+        isDefault: Value(server.isDefault),
       ),
     );
   }
@@ -100,6 +112,30 @@ class AppDatabase extends _$AppDatabase {
     await (update(nasServers)..where((tbl) => tbl.id.equals(id))).write(
       NasServersCompanion(lastConnected: Value(DateTime.now())),
     );
+  }
+
+  Future<models.NasServer?> getDefaultServer() async {
+    final query = select(nasServers)
+      ..where((tbl) => tbl.isDefault.equals(true));
+    final row = await query.getSingleOrNull();
+    return row != null ? _mapRowToNasServer(row) : null;
+  }
+
+  Future<void> setDefaultServer(String id) async {
+    await transaction(() async {
+      // First, clear any existing default server
+      await (update(nasServers)..where((tbl) => tbl.isDefault.equals(true)))
+          .write(NasServersCompanion(isDefault: const Value(false)));
+      // Then set the new default server
+      await (update(nasServers)..where((tbl) => tbl.id.equals(id))).write(
+        NasServersCompanion(isDefault: const Value(true)),
+      );
+    });
+  }
+
+  Future<void> clearDefaultServer() async {
+    await (update(nasServers)..where((tbl) => tbl.isDefault.equals(true)))
+        .write(NasServersCompanion(isDefault: const Value(false)));
   }
 
   models.NasServer _mapRowToNasServer(NasServerData row) {
@@ -120,6 +156,7 @@ class AppDatabase extends _$AppDatabase {
       allowUntrustedCertificates: row.allowUntrustedCertificates,
       lastConnected: row.lastConnected,
       isActive: row.isActive,
+      isDefault: row.isDefault,
     );
   }
 }

--- a/lib/services/database.g.dart
+++ b/lib/services/database.g.dart
@@ -147,6 +147,21 @@ class $NasServersTable extends NasServers
     ),
     defaultValue: const Constant(true),
   );
+  static const VerificationMeta _isDefaultMeta = const VerificationMeta(
+    'isDefault',
+  );
+  @override
+  late final GeneratedColumn<bool> isDefault = GeneratedColumn<bool>(
+    'is_default',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_default" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -161,6 +176,7 @@ class $NasServersTable extends NasServers
     allowUntrustedCertificates,
     lastConnected,
     isActive,
+    isDefault,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -262,6 +278,12 @@ class $NasServersTable extends NasServers
         isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta),
       );
     }
+    if (data.containsKey('is_default')) {
+      context.handle(
+        _isDefaultMeta,
+        isDefault.isAcceptableOrUnknown(data['is_default']!, _isDefaultMeta),
+      );
+    }
     return context;
   }
 
@@ -319,6 +341,10 @@ class $NasServersTable extends NasServers
         DriftSqlType.bool,
         data['${effectivePrefix}is_active'],
       )!,
+      isDefault: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_default'],
+      )!,
     );
   }
 
@@ -341,6 +367,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
   final bool allowUntrustedCertificates;
   final DateTime? lastConnected;
   final bool isActive;
+  final bool isDefault;
   const NasServerData({
     required this.id,
     required this.name,
@@ -354,6 +381,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
     required this.allowUntrustedCertificates,
     this.lastConnected,
     required this.isActive,
+    required this.isDefault,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -378,6 +406,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
       map['last_connected'] = Variable<DateTime>(lastConnected);
     }
     map['is_active'] = Variable<bool>(isActive);
+    map['is_default'] = Variable<bool>(isDefault);
     return map;
   }
 
@@ -399,6 +428,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
           ? const Value.absent()
           : Value(lastConnected),
       isActive: Value(isActive),
+      isDefault: Value(isDefault),
     );
   }
 
@@ -422,6 +452,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
       ),
       lastConnected: serializer.fromJson<DateTime?>(json['lastConnected']),
       isActive: serializer.fromJson<bool>(json['isActive']),
+      isDefault: serializer.fromJson<bool>(json['isDefault']),
     );
   }
   @override
@@ -442,6 +473,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
       ),
       'lastConnected': serializer.toJson<DateTime?>(lastConnected),
       'isActive': serializer.toJson<bool>(isActive),
+      'isDefault': serializer.toJson<bool>(isDefault),
     };
   }
 
@@ -458,6 +490,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
     bool? allowUntrustedCertificates,
     Value<DateTime?> lastConnected = const Value.absent(),
     bool? isActive,
+    bool? isDefault,
   }) => NasServerData(
     id: id ?? this.id,
     name: name ?? this.name,
@@ -474,6 +507,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
         ? lastConnected.value
         : this.lastConnected,
     isActive: isActive ?? this.isActive,
+    isDefault: isDefault ?? this.isDefault,
   );
   NasServerData copyWithCompanion(NasServersCompanion data) {
     return NasServerData(
@@ -495,6 +529,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
           ? data.lastConnected.value
           : this.lastConnected,
       isActive: data.isActive.present ? data.isActive.value : this.isActive,
+      isDefault: data.isDefault.present ? data.isDefault.value : this.isDefault,
     );
   }
 
@@ -512,7 +547,8 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
           ..write('useHttps: $useHttps, ')
           ..write('allowUntrustedCertificates: $allowUntrustedCertificates, ')
           ..write('lastConnected: $lastConnected, ')
-          ..write('isActive: $isActive')
+          ..write('isActive: $isActive, ')
+          ..write('isDefault: $isDefault')
           ..write(')'))
         .toString();
   }
@@ -531,6 +567,7 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
     allowUntrustedCertificates,
     lastConnected,
     isActive,
+    isDefault,
   );
   @override
   bool operator ==(Object other) =>
@@ -547,7 +584,8 @@ class NasServerData extends DataClass implements Insertable<NasServerData> {
           other.useHttps == this.useHttps &&
           other.allowUntrustedCertificates == this.allowUntrustedCertificates &&
           other.lastConnected == this.lastConnected &&
-          other.isActive == this.isActive);
+          other.isActive == this.isActive &&
+          other.isDefault == this.isDefault);
 }
 
 class NasServersCompanion extends UpdateCompanion<NasServerData> {
@@ -563,6 +601,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
   final Value<bool> allowUntrustedCertificates;
   final Value<DateTime?> lastConnected;
   final Value<bool> isActive;
+  final Value<bool> isDefault;
   final Value<int> rowid;
   const NasServersCompanion({
     this.id = const Value.absent(),
@@ -577,6 +616,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
     this.allowUntrustedCertificates = const Value.absent(),
     this.lastConnected = const Value.absent(),
     this.isActive = const Value.absent(),
+    this.isDefault = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   NasServersCompanion.insert({
@@ -592,6 +632,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
     this.allowUntrustedCertificates = const Value.absent(),
     this.lastConnected = const Value.absent(),
     this.isActive = const Value.absent(),
+    this.isDefault = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        name = Value(name),
@@ -611,6 +652,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
     Expression<bool>? allowUntrustedCertificates,
     Expression<DateTime>? lastConnected,
     Expression<bool>? isActive,
+    Expression<bool>? isDefault,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -627,6 +669,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
         'allow_untrusted_certificates': allowUntrustedCertificates,
       if (lastConnected != null) 'last_connected': lastConnected,
       if (isActive != null) 'is_active': isActive,
+      if (isDefault != null) 'is_default': isDefault,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -644,6 +687,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
     Value<bool>? allowUntrustedCertificates,
     Value<DateTime?>? lastConnected,
     Value<bool>? isActive,
+    Value<bool>? isDefault,
     Value<int>? rowid,
   }) {
     return NasServersCompanion(
@@ -660,6 +704,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
           allowUntrustedCertificates ?? this.allowUntrustedCertificates,
       lastConnected: lastConnected ?? this.lastConnected,
       isActive: isActive ?? this.isActive,
+      isDefault: isDefault ?? this.isDefault,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -705,6 +750,9 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
     if (isActive.present) {
       map['is_active'] = Variable<bool>(isActive.value);
     }
+    if (isDefault.present) {
+      map['is_default'] = Variable<bool>(isDefault.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -726,6 +774,7 @@ class NasServersCompanion extends UpdateCompanion<NasServerData> {
           ..write('allowUntrustedCertificates: $allowUntrustedCertificates, ')
           ..write('lastConnected: $lastConnected, ')
           ..write('isActive: $isActive, ')
+          ..write('isDefault: $isDefault, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -757,6 +806,7 @@ typedef $$NasServersTableCreateCompanionBuilder =
       Value<bool> allowUntrustedCertificates,
       Value<DateTime?> lastConnected,
       Value<bool> isActive,
+      Value<bool> isDefault,
       Value<int> rowid,
     });
 typedef $$NasServersTableUpdateCompanionBuilder =
@@ -773,6 +823,7 @@ typedef $$NasServersTableUpdateCompanionBuilder =
       Value<bool> allowUntrustedCertificates,
       Value<DateTime?> lastConnected,
       Value<bool> isActive,
+      Value<bool> isDefault,
       Value<int> rowid,
     });
 
@@ -842,6 +893,11 @@ class $$NasServersTableFilterComposer
 
   ColumnFilters<bool> get isActive => $composableBuilder(
     column: $table.isActive,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isDefault => $composableBuilder(
+    column: $table.isDefault,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -914,6 +970,11 @@ class $$NasServersTableOrderingComposer
     column: $table.isActive,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<bool> get isDefault => $composableBuilder(
+    column: $table.isDefault,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$NasServersTableAnnotationComposer
@@ -966,6 +1027,9 @@ class $$NasServersTableAnnotationComposer
 
   GeneratedColumn<bool> get isActive =>
       $composableBuilder(column: $table.isActive, builder: (column) => column);
+
+  GeneratedColumn<bool> get isDefault =>
+      $composableBuilder(column: $table.isDefault, builder: (column) => column);
 }
 
 class $$NasServersTableTableManager
@@ -1011,6 +1075,7 @@ class $$NasServersTableTableManager
                 Value<bool> allowUntrustedCertificates = const Value.absent(),
                 Value<DateTime?> lastConnected = const Value.absent(),
                 Value<bool> isActive = const Value.absent(),
+                Value<bool> isDefault = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => NasServersCompanion(
                 id: id,
@@ -1025,6 +1090,7 @@ class $$NasServersTableTableManager
                 allowUntrustedCertificates: allowUntrustedCertificates,
                 lastConnected: lastConnected,
                 isActive: isActive,
+                isDefault: isDefault,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -1041,6 +1107,7 @@ class $$NasServersTableTableManager
                 Value<bool> allowUntrustedCertificates = const Value.absent(),
                 Value<DateTime?> lastConnected = const Value.absent(),
                 Value<bool> isActive = const Value.absent(),
+                Value<bool> isDefault = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => NasServersCompanion.insert(
                 id: id,
@@ -1055,6 +1122,7 @@ class $$NasServersTableTableManager
                 allowUntrustedCertificates: allowUntrustedCertificates,
                 lastConnected: lastConnected,
                 isActive: isActive,
+                isDefault: isDefault,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/test/e2e/mocked_complete_edit_flow_test.dart
+++ b/test/e2e/mocked_complete_edit_flow_test.dart
@@ -126,6 +126,32 @@ class MockServerProvider extends ChangeNotifier implements ServerProvider {
 
   @override
   String? get userError => null;
+
+  @override
+  Future<void> setDefaultServer(String serverId) async {
+    await _database.setDefaultServer(serverId);
+    await loadServers();
+  }
+
+  @override
+  Future<void> clearDefaultServer() async {
+    await _database.clearDefaultServer();
+    await loadServers();
+  }
+
+  @override
+  Future<void> loadServersAndAutoSelect() async {
+    await loadServers();
+  }
+
+  @override
+  NasServer? get defaultServer {
+    try {
+      return _servers.firstWhere((server) => server.isDefault);
+    } catch (e) {
+      return null;
+    }
+  }
 }
 
 class MockPoolProvider extends ChangeNotifier implements PoolProvider {

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -33,6 +33,71 @@ void main() {
   });
 
   group('ServerProvider', () {
+    test('should set and get default server', () async {
+      // Initially no default server
+      expect(serverProvider.defaultServer, isNull);
+
+      // Set default server
+      await serverProvider.setDefaultServer(testServer.id);
+      await serverProvider.loadServers();
+
+      // Verify default server is set
+      final defaultServer = serverProvider.defaultServer;
+      expect(defaultServer, isNotNull);
+      expect(defaultServer?.id, testServer.id);
+      expect(defaultServer?.isDefault, isTrue);
+    });
+
+    test('should clear default server', () async {
+      // Set server as default first
+      await serverProvider.setDefaultServer(testServer.id);
+      await serverProvider.loadServers();
+      expect(serverProvider.defaultServer, isNotNull);
+
+      // Clear default server
+      await serverProvider.clearDefaultServer();
+
+      // Verify no default server
+      expect(serverProvider.defaultServer, isNull);
+    });
+
+    test('should auto-select single server', () async {
+      // Clear any existing selection
+      serverProvider.clearSelectedServer();
+      expect(serverProvider.selectedServer, isNull);
+
+      // Auto-select should pick the only server
+      await serverProvider.loadServersAndAutoSelect();
+      expect(serverProvider.selectedServer, isNotNull);
+      expect(serverProvider.selectedServer?.id, testServer.id);
+    });
+
+    test(
+      'should auto-select default server when multiple servers exist',
+      () async {
+        // Add a second server
+        final secondServer = NasServer.create(
+          name: 'Second Server',
+          host: '192.168.1.101',
+          username: 'admin',
+          password: 'password',
+        );
+        await serverProvider.addServer(secondServer);
+
+        // Set second server as default
+        await serverProvider.setDefaultServer(secondServer.id);
+
+        // Clear any existing selection
+        serverProvider.clearSelectedServer();
+        expect(serverProvider.selectedServer, isNull);
+
+        // Auto-select should pick the default server
+        await serverProvider.loadServersAndAutoSelect();
+        expect(serverProvider.selectedServer, isNotNull);
+        expect(serverProvider.selectedServer?.id, secondServer.id);
+      },
+    );
+
     test('should update server and refresh selected server', () async {
       // Set the test server as active
       serverProvider.selectServer(testServer);


### PR DESCRIPTION
## Summary
- Implements configurable default server functionality for automatic selection on app launch
- Adds auto-selection logic that works for both single server and multi-server scenarios
- Includes UI controls for managing default server designation

## Changes Made
- Added `isDefault` field to `NasServer` model with database migration to schema v2
- Enhanced `ServerProvider` with auto-selection logic that prioritizes default server, falls back to single server
- Updated `HomeScreen` to automatically navigate to selected server on launch
- Added toggle in edit server screen to set/clear default server designation
- Implemented database methods to ensure only one server can be default at a time
- Added comprehensive tests covering all default server scenarios

## Test Plan
- [x] Users with single server: app automatically selects and navigates to server
- [x] Users with multiple servers: default server is auto-selected if configured
- [x] Users can designate a server as default via edit screen toggle
- [x] Only one server can be marked as default at a time
- [x] Default server preference persists between app launches
- [x] Users can change or remove default server designation
- [x] All existing functionality remains intact

Resolves #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set a default server, ensuring only one server can be marked as default at a time.
  * Introduced an option in the server editing screen to toggle the default server status.
  * The app now automatically selects the default server (or the only server) on startup and navigates to its details.

* **Bug Fixes**
  * Improved server selection logic to prioritize the default server when available.

* **Tests**
  * Added comprehensive tests for default server management and auto-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->