### PR TITLE
fix: remove temporary exceptions

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -29,9 +29,5 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
-	<key>com.apple.security.temporary-exception.shared-preference.read-write</key>
-	<true/>
-	<key>com.apple.security.temporary-exception.keychain</key>
-	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -12,8 +12,6 @@
 	<array>
 		<string>$(AppIdentifierPrefix)com.cedricziel.truehub.shared</string>
 	</array>
-	<key>com.apple.security.temporary-exception.shared-preference.read-write</key>
-	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.cedricziel.trueapp</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS app entitlements by removing temporary exception permissions to enhance security. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->