### PR TITLE
fix: get CI back to green, refresh dependencies and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: macos-latest
     # A hanging test used to keep this job alive until the runner limit was
     # reached, which hides the failure and blocks the queue. Fail fast instead.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   test:
     runs-on: macos-latest
+    # A hanging test used to keep this job alive until the runner limit was
+    # reached, which hides the failure and blocks the queue. Fail fast instead.
+    timeout-minutes: 45
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,14 @@ jobs:
     - name: Build iOS (no codesign)
       run: flutter build ios --no-codesign
 
-    - name: Build macOS
+    # `flutter build macos` has no --no-codesign flag, and the runner has no
+    # signing identity, so the Release configuration's Manual signing fails
+    # with "No profiles for 'com.cedricziel.trueapp' were found". Flutter
+    # forwards FLUTTER_XCODE_<setting> to xcodebuild, which lets CI compile
+    # without signing - the same intent as --no-codesign on the iOS step.
+    - name: Build macOS (no codesign)
+      env:
+        FLUTTER_XCODE_CODE_SIGNING_ALLOWED: "NO"
+        FLUTTER_XCODE_CODE_SIGNING_REQUIRED: "NO"
+        FLUTTER_XCODE_CODE_SIGN_IDENTITY: ""
       run: flutter build macos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ Repository pattern with drift (SQLite) database:
 
 ### Key Implementation Notes
 1. The app supports multiple TrueNAS server connections stored securely in SQLite
-2. API credentials are stored in the database (consider security implications)
+2. Passwords live in the native Keychain via `NativeKeychainService`, never in the
+   database. Server metadata, including the username, is stored by the repository
+   layer: CloudKit on Apple platforms, SQLite elsewhere
 3. Uses dio for HTTP requests to TrueNAS API
 4. Native platform features through iOS/macOS specific implementations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,16 @@ Repository pattern with drift (SQLite) database:
 4. Native platform features through iOS/macOS specific implementations
 
 ## Current Development Status
-According to README.md:
-- ✅ Completed: Basic UI, server management, navigation
-- 🚧 In Progress: Pool management UI, dataset operations
-- 📋 Planned: Snapshot management, user management, system monitoring
+- ✅ Completed: server management, JSON-RPC API client, CloudKit/SQLite repository layer,
+  Keychain + biometrics, pools & datasets, app catalog with live resource usage, file browsing,
+  system stats, macOS tray, `truenas_native_plugins` package
+- 🚧 In Progress: adaptive Cupertino sidebar navigation (#54), splitting large screens into
+  smaller widgets (#35), raising test coverage towards 80%
+- 📋 Planned: alerts & push notifications (#25), job monitor (#26), service management (#27),
+  dashboard widgets (#28), system updates (#29), network interfaces (#30), pool health/scrub (#31),
+  mDNS discovery (#39)
 
-When implementing new features, follow the existing patterns and ensure compatibility with both iOS and macOS platforms.
+See README.md for the user-facing version of this list.
 
 ## Tooling Notes
 - `gtimeout` is used for adding timeouts to bash commands

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The app follows a clean architecture pattern with:
 
 ### Prerequisites
 
-- Flutter SDK (3.8.0 or higher)
+- Flutter SDK 3.32.6 or newer (bundles Dart 3.8.1, which `pubspec.yaml` requires)
 - Xcode (for iOS/macOS development)
 - CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ A Flutter application for managing TrueNAS servers from iOS and macOS devices.
 ## Features
 
 - **Multi-Server Management**: Register and manage multiple TrueNAS servers
-- **Secure Storage**: Server credentials are stored locally using encrypted SQLite database
+- **Secure Storage**: Credentials live in the native Keychain (biometric unlock); server metadata syncs via CloudKit on Apple platforms and SQLite elsewhere
 - **Native UI**: Built with Cupertino widgets for native iOS/macOS experience
-- **Server Health Monitoring**: View CPU, memory, disk usage, and temperatures (coming soon)
-- **File Management**: Browse and manage files on your TrueNAS servers (coming soon)
+- **Server Health Monitoring**: View CPU, memory, disk usage and system stats
+- **File Management**: Browse files on your TrueNAS servers
+- **App Management**: Browse installed apps, view live resource usage and edit app configuration
+- **Storage**: Inspect pools and datasets
+- **macOS Menu Bar**: Quick access to servers from the system tray
 
 ## Architecture
 
@@ -70,20 +73,34 @@ lib/
 
 ### Completed
 - ✅ Project setup and architecture
-- ✅ Server management (add, edit, delete)
-- ✅ Local database integration
-- ✅ Basic navigation and UI
+- ✅ Multi-server management (add, edit, delete, default server)
+- ✅ TrueNAS JSON-RPC API client with keepalive (ping/pong)
+- ✅ Repository layer with CloudKit sync on Apple platforms and SQLite elsewhere
+- ✅ Secure credential storage via native Keychain with biometric unlock
+- ✅ Storage pools and dataset browsing
+- ✅ App catalog: list, detail, configuration and live resource usage
+- ✅ File browsing
+- ✅ System stats and server health view
+- ✅ Connection status / network awareness
+- ✅ macOS menu bar (tray) integration
+- ✅ Native plugins extracted into the reusable `truenas_native_plugins` package
 
 ### In Progress
-- 🚧 TrueNAS API integration
-- 🚧 File browsing functionality
-- 🚧 Server health monitoring
+- 🚧 Adaptive Cupertino sidebar navigation ([#54](https://github.com/cedricziel/trueapp/issues/54))
+- 🚧 Breaking large screens into smaller reusable widgets ([#35](https://github.com/cedricziel/trueapp/issues/35))
+- 🚧 Raising test coverage towards the 80% goal
 
 ### Planned
-- 📋 Real-time server metrics
+- 📋 Real-time alerts with push notifications ([#25](https://github.com/cedricziel/trueapp/issues/25))
+- 📋 Job/task monitor with progress tracking ([#26](https://github.com/cedricziel/trueapp/issues/26))
+- 📋 Service management (start/stop/restart) ([#27](https://github.com/cedricziel/trueapp/issues/27))
+- 📋 Customizable dashboard with widgets ([#28](https://github.com/cedricziel/trueapp/issues/28))
+- 📋 System update management ([#29](https://github.com/cedricziel/trueapp/issues/29))
+- 📋 Network interface management ([#30](https://github.com/cedricziel/trueapp/issues/30))
+- 📋 Pool health and scrub monitoring ([#31](https://github.com/cedricziel/trueapp/issues/31))
+- 📋 Server discovery wizard with mDNS ([#39](https://github.com/cedricziel/trueapp/issues/39))
 - 📋 File upload/download
-- 📋 Push notifications for alerts
-- 📋 Dark mode support
+- 📋 App Store / TestFlight distribution ([#16](https://github.com/cedricziel/trueapp/issues/16), [#51](https://github.com/cedricziel/trueapp/issues/51))
 
 ## Contributing
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,30 +12,35 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - permission_handler_apple (9.3.0):
+  - permission_handler_apple (9.4.8):
     - Flutter
-  - sqlite3 (3.50.2):
-    - sqlite3/common (= 3.50.2)
-  - sqlite3/common (3.50.2)
-  - sqlite3/dbstatvtab (3.50.2):
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
     - sqlite3/common
-  - sqlite3/fts5 (3.50.2):
+  - sqlite3/fts5 (3.52.0):
     - sqlite3/common
-  - sqlite3/math (3.50.2):
+  - sqlite3/math (3.52.0):
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.50.2):
+  - sqlite3/perf-threadsafe (3.52.0):
     - sqlite3/common
-  - sqlite3/rtree (3.50.2):
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
     - FlutterMacOS
-    - sqlite3 (~> 3.50.1)
+    - sqlite3 (~> 3.52.0)
     - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/math
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
+    - sqlite3/session
+  - truenas_native_plugins (0.1.0):
+    - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -48,6 +53,7 @@ DEPENDENCIES:
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
+  - truenas_native_plugins (from `.symlinks/plugins/truenas_native_plugins/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -71,21 +77,24 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   sqlite3_flutter_libs:
     :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
+  truenas_native_plugins:
+    :path: ".symlinks/plugins/truenas_native_plugins/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  local_auth_darwin: d2e8c53ef0c4f43c646462e3415432c4dab3ae19
-  network_info_plus: cf61925ab5205dce05a4f0895989afdb6aade5fc
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  sqlite3: 3e82a2daae39ba3b41ae6ee84a130494585460fc
-  sqlite3_flutter_libs: e7fc8c9ea2200ff3271f08f127842131746b70e2
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  local_auth_darwin: fa4b06454df7df8e97c18d7ee55151c57e7af0de
+  network_info_plus: 6613d9d7cdeb0e6f366ed4dbe4b3c51c52d567a9
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
+  truenas_native_plugins: a5e975082bea74e12f3fb60c8b25f201f0e55330
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -413,11 +413,7 @@ class TrueNasApiClient implements ApiClientInterface {
         print('TrueNAS API: Validating login for user: $username');
       }
       final result = await _client!
-          .sendRequest('auth.login', [
-            username,
-            password,
-            if (otpToken != null) otpToken,
-          ])
+          .sendRequest('auth.login', [username, password, ?otpToken])
           .timeout(const Duration(seconds: 10));
       if (kDebugMode) {
         print('TrueNAS API: Login validation result: $result');

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -12,28 +12,31 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sqlite3 (3.50.2):
-    - sqlite3/common (= 3.50.2)
-  - sqlite3/common (3.50.2)
-  - sqlite3/dbstatvtab (3.50.2):
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
     - sqlite3/common
-  - sqlite3/fts5 (3.50.2):
+  - sqlite3/fts5 (3.52.0):
     - sqlite3/common
-  - sqlite3/math (3.50.2):
+  - sqlite3/math (3.52.0):
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.50.2):
+  - sqlite3/perf-threadsafe (3.52.0):
     - sqlite3/common
-  - sqlite3/rtree (3.50.2):
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
     - FlutterMacOS
-    - sqlite3 (~> 3.50.1)
+    - sqlite3 (~> 3.52.0)
     - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/math
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
+    - sqlite3/session
   - tray_manager (0.0.1):
     - FlutterMacOS
   - truenas_native_plugins (0.1.0):
@@ -80,18 +83,18 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
-  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
+  connectivity_plus: 0a976dfd033b59192912fa3c6c7b54aab5093802
+  flutter_secure_storage_macos: c2754d3483d20bb207bb9e5a14f1b8e771abcdb9
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  local_auth_darwin: d2e8c53ef0c4f43c646462e3415432c4dab3ae19
-  network_info_plus: 21d1cd6a015ccb2fdff06a1fbfa88d54b4e92f61
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  sqlite3: 3e82a2daae39ba3b41ae6ee84a130494585460fc
-  sqlite3_flutter_libs: e7fc8c9ea2200ff3271f08f127842131746b70e2
-  tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
-  truenas_native_plugins: a8a4a8df3f75eaeb2f7b9ef30eabe84e405a601c
-  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  local_auth_darwin: fa4b06454df7df8e97c18d7ee55151c57e7af0de
+  network_info_plus: 2cb02d8435635eae13b3b79279681985121cf30c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
+  tray_manager: c2a678ee19e2a094f0c2d03660ee2c3e81cea8ab
+  truenas_native_plugins: 2b234f3726a22840001a3534747f40f5509b709e
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
 
 PODFILE CHECKSUM: 7eb978b976557c8c1cd717d8185ec483fd090a82
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: abf63d42450c7ad6d8188887d16eeba2f1ff92ea8d8dc673213e99fb3c02b194
+      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.7"
+    version: "7.7.1"
   args:
     dependency: transitive
     description:
@@ -45,50 +45,50 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.1.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.1.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.7.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.2"
+    version: "9.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.12.7"
   characters:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -165,18 +165,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "051849e2bd7c7b3bc5844ea0d096609ddc3a859890ec3a9ac4a65a2620cc1f99"
+      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.3.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   console:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -213,74 +213,74 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_pre_commit
-      sha256: "8997e3e8d445dac07e3f248a007454228d04f193371879b5de6c1738efc052a1"
+      sha256: ea6b1e77383462957213425a5b85c4641b50cbe2bc0a6db574642c30713c9358
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.5"
+    version: "5.4.7"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      sha256: a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.15"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   drift:
     dependency: "direct main"
     description:
       name: drift
-      sha256: e60c715f045dd33624fc533efb0075e057debec9f39e83843e518f488a0e21fb
+      sha256: "83290a32ae006a7535c5ecf300722cb77177250d9df4ee2becc5fa8a36095114"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.29.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "7ad88b8982e753eadcdbc0ea7c7d30500598af733601428b5c9d264baf5106d6"
+      sha256: "6019f827544e77524ffd5134ae0cb75dfd92ef5ef3e269872af92840c929cd43"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.29.0"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: "0cadbf3b8733409a6cf61d18ba2e94e149df81df7de26f48ae0695b48fd71922"
+      sha256: b7534bf320aac5213259aac120670ba67b63a1fd010505babc436ff86083818f
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.7"
   equatable:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -317,10 +317,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "577aeac8ca414c25333334d7c4bb246775234c0e44b38b10a82b559dd4d764e7"
+      sha256: d3f82f4a38e33ba23d05a08ff304d7d8b22d2a59a5503f20bd802966e915db89
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -338,10 +338,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      sha256: c2fe1001710127dfa7da89977a08d591398370d099aacdaa6d44da7eb14b8476
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.28"
+    version: "2.0.31"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -394,10 +394,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_slidable
-      sha256: ab7dbb16f783307c9d7762ede2593ce32c220ba2ba0fd540a3db8e9a3acba71a
+      sha256: ea369262929d3cc6ebf9d8a00c196127966f117fe433a5e5cb47fb08008ca203
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      sha256: "218aeb56050c714f62a3182775320dfa04602b55074873e24e31bbd39bda96fb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   graphs:
     dependency: transitive
     description:
@@ -440,14 +440,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -476,10 +468,10 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      sha256: "2635216ca6a737e60de577ffa1a48a0bec76ca8a62917cfc1bb88c14c570646f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   js:
     dependency: transitive
     description:
@@ -500,10 +492,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_rpc_2
-      sha256: "3c46c2633aec07810c3d6a2eb08d575b5b4072980db08f1344e66aeb53d6e4a7"
+      sha256: "82dfd37d3b2e5030ae4729e1d7f5538cbc45eb1c73d618b9272931facac3bec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -532,10 +524,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   local_auth:
     dependency: "direct main"
     description:
@@ -548,26 +540,26 @@ packages:
     dependency: transitive
     description:
       name: local_auth_android
-      sha256: "63ad7ca6396290626dc0cb34725a939e4cfe965d80d36112f08d49cf13a8136e"
+      sha256: "48924f4a8b3cc45994ad5993e2e232d3b00788a305c1bf1c7db32cef281ce9a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.49"
+    version: "1.0.52"
   local_auth_darwin:
     dependency: transitive
     description:
       name: local_auth_darwin
-      sha256: "25163ce60a5a6c468cf7a0e3dc8a165f824cabc2aa9e39a5e9fc5c2311b7686f"
+      sha256: "0e9706a8543a4a2eee60346294d6a633dd7c3ee60fae6b752570457c4ff32055"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   local_auth_platform_interface:
     dependency: transitive
     description:
       name: local_auth_platform_interface
-      sha256: "1b842ff177a7068442eae093b64abe3592f816afd2a533c0ebcdbe40f9d2075a"
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.10"
+    version: "1.1.0"
   local_auth_windows:
     dependency: transitive
     description:
@@ -620,10 +612,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      sha256: bd47de35f07e27267e69c8c8b22edf9473bfee170a60d60fcc93730c5144b7f6
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   nested:
     dependency: transitive
     description:
@@ -684,18 +676,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "3b4c1fc3aa55ddc9cd4aa6759984330d5c8e66aa7702a6223c61540dc6380c37"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.19"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -724,10 +716,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:
@@ -740,42 +732,42 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      sha256: f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.7"
+    version: "9.6.1"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+5"
+    version: "0.1.4+1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -796,34 +788,34 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "4177f68c237ea2128d1bee66ac17b2ce05ba3dbaafcbdd54c5d40a39d0b6b11c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.3"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      sha256: "261236774e8b1d69cfc6b9eabbc96c40f25e7a2d6b171f3385d4f65d5734fb24"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      sha256: c38b81cbf34450b67e0265d73433569d12e34782e30ed769c9cc99c9d5f2e796
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   recase:
     dependency: transitive
     description:
@@ -873,10 +865,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: "800f12fb87434defa13432ab37e33051b43b290a174e15259563b043cda40c46"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.0.0"
   source_span:
     dependency: transitive
     description:
@@ -885,38 +877,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
-  sprintf:
-    dependency: transitive
-    description:
-      name: sprintf
-      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: c0503c69b44d5714e6abbf4c1f51a3c3cc42b75ce785f44404765e4635481d38
+      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.6"
+    version: "2.9.4"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: e07232b998755fe795655c56d1f5426e0190c9c435e1752d39e7b1cd33699c71
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.34"
+    version: "0.5.42"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
+      sha256: "162435ede92bcc793ea939fdc0452eef0a73d11f8ed053b58a89792fba749da5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.41.0"
+    version: "0.42.1"
   stack_trace:
     dependency: transitive
     description:
@@ -945,10 +929,10 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      sha256: a00e5f18bffc764f923e7dec1038527f7fe7a1791361a7117f0358193f13d53a
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -985,10 +969,10 @@ packages:
     dependency: "direct main"
     description:
       name: tray_manager
-      sha256: ad18c4cd73003097d182884bacb0578ad2865f3ab842a0ad00f6d043ed49eaf0
+      sha256: "1a659b08baa6e9b91ef8ce16eda37740de398be1c4cf322b8a1ddfef25c68c5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.3"
   truenas_native_plugins:
     dependency: "direct main"
     description:
@@ -1016,34 +1000,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      sha256: "81777b08c498a292d93ff2feead633174c386291e35612f8da438d6e92c4447e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.16"
+    version: "6.3.20"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.4"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1064,18 +1048,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -1096,10 +1080,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:
@@ -1128,10 +1112,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1144,18 +1128,18 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      sha256: f67cdd8e07d3c6329146aaef1ba043542b3134c12489f553ca9a7435d1068aea
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.27.4"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
   # Network connectivity detection
-  connectivity_plus: ^6.1.4
+  connectivity_plus: ^7.0.0
   network_info_plus: ^6.1.4
   permission_handler: ^12.0.1
 
@@ -94,7 +94,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   drift_dev: ^2.27.0
   build_runner: ^2.5.4
-  dart_pre_commit: ^5.4.5
+  dart_pre_commit: ^5.4.7
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/e2e/complete_edit_flow_test.dart
+++ b/test/e2e/complete_edit_flow_test.dart
@@ -61,7 +61,7 @@ void main() {
 
   tearDown(() async {
     await TestProviders.disposeTestStack(
-      provider: serverProvider,
+      providers: [serverProvider, poolProvider],
       service: unifiedServerService,
       database: database,
     );

--- a/test/e2e/complete_edit_flow_test.dart
+++ b/test/e2e/complete_edit_flow_test.dart
@@ -11,8 +11,22 @@ import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:truehub/screens/home_screen.dart';
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
+import '../helpers/form_finders.dart';
+import '../helpers/pump_helpers.dart';
 import '../helpers/test_providers.dart';
 
+/// End-to-end coverage for editing a server through the real screen stack:
+/// Home → Server Detail → Edit → Save.
+///
+/// Two constraints shape every test in this file:
+///
+/// * `ServerDetailScreen` renders an indefinite activity indicator while it
+///   authenticates, so `pumpAndSettle` would never return. All waiting goes
+///   through the bounded helpers in `pump_helpers.dart`.
+/// * Everything the edit flow persists goes through drift, which only makes
+///   progress outside the `FakeAsync` zone of `testWidgets`. Waiting for such
+///   an effect therefore uses [pumpUntilAsync], and direct database reads use
+///   [runRealAsync].
 void main() {
   late AppDatabase database;
   late ServerProvider serverProvider;
@@ -30,7 +44,6 @@ void main() {
     serverProvider = ServerProvider(unifiedServerService);
     poolProvider = PoolProvider(unifiedServerService);
 
-    // Create and register a test server
     testServer = NasServer.create(
       name: 'Test TrueNAS Server',
       host: '192.168.1.100',
@@ -47,398 +60,215 @@ void main() {
   });
 
   tearDown(() async {
-    await database.close();
+    await TestProviders.disposeTestStack(
+      provider: serverProvider,
+      service: unifiedServerService,
+      database: database,
+    );
   });
 
+  /// The full provider stack the home and detail screens depend on.
+  Widget createTestApp() {
+    return MultiProvider(
+      providers: [
+        Provider<AppDatabase>.value(value: database),
+        Provider<UnifiedServerService>.value(value: unifiedServerService),
+        ChangeNotifierProvider.value(value: serverProvider),
+        ChangeNotifierProvider.value(value: poolProvider),
+        ChangeNotifierProvider(
+          create: (_) => AppProvider(
+            database: database,
+            serverService: unifiedServerService,
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => SystemStatsProvider(unifiedServerService),
+        ),
+        ChangeNotifierProvider(create: (_) => ConnectionStatusProvider()),
+      ],
+      child: const CupertinoApp(home: HomeScreen()),
+    );
+  }
+
+  /// Launches the app and waits until the registered server is listed.
+  Future<void> pumpHomeScreen(WidgetTester tester) async {
+    await tester.pumpWidget(createTestApp());
+    await pumpUntilAsync(
+      tester,
+      () => find.text('Test TrueNAS Server').evaluate().isNotEmpty,
+    );
+  }
+
+  /// Taps the server in the list and waits for the detail screen.
+  ///
+  /// The detail screen is identified by the ellipsis button in its navigation
+  /// bar; the body itself may still be showing the authentication placeholder.
+  Future<void> openServerDetail(WidgetTester tester) async {
+    await tester.tap(find.text('Test TrueNAS Server').first);
+    await settleRouteTransition(tester);
+    await pumpUntilAsync(
+      tester,
+      () => find.byIcon(CupertinoIcons.ellipsis).evaluate().isNotEmpty,
+    );
+  }
+
+  /// Opens the detail screen's action sheet and navigates to the edit screen.
+  Future<void> openEditScreen(WidgetTester tester) async {
+    await tapWhenUnambiguous(tester, find.byIcon(CupertinoIcons.ellipsis));
+    await settleRouteTransition(tester);
+
+    expect(find.byType(CupertinoActionSheet), findsOneWidget);
+
+    await tapWhenUnambiguous(tester, find.text('Edit Server'));
+    await settleRouteTransition(tester);
+
+    // The edit screen carries 'Edit Server' as its navigation bar title.
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  }
+
   group('Complete Edit Flow End-to-End Test', () {
-    testWidgets(
-      'should complete full user journey: Home → Server Detail → Edit → Save → Provider Update',
-      (WidgetTester tester) async {
-        // Create the complete app with providers
-        Widget createTestApp() {
-          return MultiProvider(
-            providers: [
-              Provider<AppDatabase>.value(value: database),
-              Provider<UnifiedServerService>.value(value: unifiedServerService),
-              ChangeNotifierProvider.value(value: serverProvider),
-              ChangeNotifierProvider.value(value: poolProvider),
-              ChangeNotifierProvider(
-                create: (_) => AppProvider(
-                  database: database,
-                  serverService: unifiedServerService,
-                ),
-              ),
-              ChangeNotifierProvider(
-                create: (_) => SystemStatsProvider(unifiedServerService),
-              ),
-              ChangeNotifierProvider(create: (_) => ConnectionStatusProvider()),
-            ],
-            child: const CupertinoApp(home: HomeScreen()),
-          );
-        }
+    testWidgets('should complete full user journey: Home → Server Detail → '
+        'Edit → Save → Provider Update', (WidgetTester tester) async {
+      // STEP 1: Home screen lists the registered server.
+      await pumpHomeScreen(tester);
 
-        await tester.pumpWidget(createTestApp());
+      expect(find.text('TrueNAS Manager'), findsOneWidget);
+      expect(find.text('Test TrueNAS Server'), findsOneWidget);
+      expect(find.text('https://192.168.1.100:443'), findsOneWidget);
+      expect(serverProvider.selectedServer, isNull);
 
-        // Wait for initial build with timeout protection
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+      // STEP 2: Opening the server selects it in the provider.
+      await openServerDetail(tester);
+      await pumpUntilAsync(tester, () => serverProvider.selectedServer != null);
 
-        // STEP 1: Verify we're on the Home Screen with our registered server
-        expect(find.text('TrueNAS Manager'), findsOneWidget);
-        expect(find.text('Test TrueNAS Server'), findsOneWidget);
-        expect(find.text('https://192.168.1.100:443'), findsOneWidget);
+      expect(serverProvider.selectedServer, isNotNull);
+      expect(serverProvider.selectedServer!.name, 'Test TrueNAS Server');
+      expect(serverProvider.selectedServer!.host, '192.168.1.100');
+      expect(serverProvider.selectedServer!.port, 443);
+      expect(serverProvider.selectedServer!.useHttps, isTrue);
+      expect(
+        serverProvider.selectedServer!.allowUntrustedCertificates,
+        isFalse,
+      );
 
-        // Verify server is not yet selected in provider
-        expect(serverProvider.selectedServer, isNull);
+      // STEP 3: Navigate into the edit screen.
+      await openEditScreen(tester);
 
-        // STEP 2: Navigate to Server Detail Screen by tapping on the server
-        await tester.tap(find.text('Test TrueNAS Server'));
-        // Wait for navigation to complete without pumpAndSettle
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
+      // STEP 4: Change the server name.
+      await tester.enterText(
+        formFieldWithLabel('Name'),
+        'Updated TrueNAS Server',
+      );
+      await tester.pump();
 
-        // Extra wait for async operations in ServerDetailScreen
-        await tester.pump(const Duration(milliseconds: 500));
+      // STEP 5: Save and wait for the write to reach the provider.
+      await tapWhenUnambiguous(tester, find.text('Save'));
+      await pumpUntilAsync(
+        tester,
+        () => serverProvider.selectedServer?.name == 'Updated TrueNAS Server',
+      );
 
-        // Additional pumps to ensure all async operations complete
-        await tester.pump(const Duration(milliseconds: 500));
-        await tester.pump(const Duration(milliseconds: 500));
+      // STEP 6: The change bubbled up to the provider, host is untouched.
+      expect(serverProvider.selectedServer?.name, 'Updated TrueNAS Server');
+      expect(serverProvider.selectedServer?.host, '192.168.1.100');
 
-        // Verify we're on the Server Detail Screen
-        // Multiple instances of server name may exist (navigation bar, content)
-        expect(find.text('Test TrueNAS Server'), findsWidgets);
+      // STEP 7: ... and was persisted.
+      final serverFromDb = await runRealAsync(
+        tester,
+        () => database.getServer(testServer.id),
+      );
+      expect(serverFromDb, isNotNull);
+      expect(serverFromDb!.name, 'Updated TrueNAS Server');
+      expect(serverFromDb.host, '192.168.1.100');
 
-        // The ServerDetailScreen might be showing loading or authentication state
-        // Let's check if we can find any of the expected widgets
-        final loadingWidget = find.byType(CupertinoActivityIndicator);
+      // STEP 8: ... and the server list reflects it too.
+      final updatedServerInList = serverProvider.servers.firstWhere(
+        (s) => s.id == testServer.id,
+      );
+      expect(updatedServerInList.name, 'Updated TrueNAS Server');
+      expect(updatedServerInList.host, '192.168.1.100');
+    });
 
-        if (loadingWidget.evaluate().isNotEmpty) {
-          // If loading, wait more
-          await tester.pump(const Duration(seconds: 1));
-          await tester.pump(const Duration(seconds: 1));
-        }
+    testWidgets('should handle edit cancellation without affecting provider '
+        'state', (WidgetTester tester) async {
+      await pumpHomeScreen(tester);
+      await openServerDetail(tester);
+      await pumpUntilAsync(tester, () => serverProvider.selectedServer != null);
 
-        expect(find.text('Host'), findsOneWidget);
-        expect(find.text('192.168.1.100'), findsOneWidget);
-        expect(find.text('Port'), findsOneWidget);
-        expect(find.text('443'), findsOneWidget);
-        expect(find.text('Protocol'), findsOneWidget);
-        expect(find.text('HTTPS'), findsOneWidget);
-        expect(find.text('Username'), findsOneWidget);
-        expect(find.text('admin'), findsOneWidget);
+      final originalServer = serverProvider.selectedServer!;
+      expect(originalServer.name, 'Test TrueNAS Server');
+      expect(originalServer.host, '192.168.1.100');
+      expect(originalServer.allowUntrustedCertificates, isFalse);
 
-        // Verify server is now selected in provider
-        expect(serverProvider.selectedServer, isNotNull);
-        expect(serverProvider.selectedServer?.name, 'Test TrueNAS Server');
-        expect(serverProvider.selectedServer?.host, '192.168.1.100');
-        expect(serverProvider.selectedServer?.port, 443);
-        expect(serverProvider.selectedServer?.useHttps, isTrue);
-        expect(
-          serverProvider.selectedServer?.allowUntrustedCertificates,
-          isFalse,
-        );
+      await openEditScreen(tester);
 
-        // STEP 3: Navigate to Edit Screen via the ellipsis menu
-        // Find ellipsis in navigation bar
-        final ellipsisButton = find.byIcon(CupertinoIcons.ellipsis);
-        expect(ellipsisButton, findsOneWidget);
+      // Type a change, then discard it.
+      await tester.enterText(formFieldWithLabel('Name'), 'Changed Server Name');
+      await tester.pump();
 
-        await tester.tap(ellipsisButton);
-        await tester.pump(const Duration(milliseconds: 100)); // Start animation
-        await tester.pump(
-          const Duration(milliseconds: 300),
-        ); // Complete animation
+      await tapWhenUnambiguous(tester, find.text('Cancel'));
+      await settleRouteTransition(tester);
 
-        // Verify action sheet is displayed
-        final actionSheet = find.byType(CupertinoActionSheet);
-        expect(actionSheet, findsOneWidget);
-        expect(find.text('Edit Server'), findsOneWidget);
+      // Back on the detail screen, nothing changed.
+      expect(find.byIcon(CupertinoIcons.ellipsis), findsOneWidget);
+      expect(serverProvider.selectedServer?.name, 'Test TrueNAS Server');
+      expect(serverProvider.selectedServer?.host, '192.168.1.100');
+      expect(
+        serverProvider.selectedServer?.allowUntrustedCertificates,
+        isFalse,
+      );
 
-        // Tap "Edit Server" in the action sheet
-        await tester.tap(find.text('Edit Server'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
-
-        // Verify we're on the Edit Server Screen
-        expect(
-          find.text('Edit Server'),
-          findsOneWidget,
-        ); // Navigation bar title
-        expect(find.text('Save'), findsOneWidget);
-        expect(find.text('Cancel'), findsOneWidget);
-
-        // STEP 4: Make changes to the server (simplified to just change name)
-        // Find and update the server name field (this should be at the top and visible)
-        final nameFields = find.byType(CupertinoTextField);
-        expect(nameFields, findsWidgets);
-
-        // Update server name (first field)
-        await tester.enterText(nameFields.first, 'Updated TrueNAS Server');
-        await tester.pump(const Duration(milliseconds: 100));
-
-        // STEP 5: Save the changes
-        // Save button should be in navigation bar and visible
-        final saveButtons = find.text('Save');
-        expect(saveButtons, findsWidgets);
-        await tester.tap(saveButtons.first, warnIfMissed: false);
-        // Use pump with duration for navigation
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
-
-        // STEP 6: Verify we're back on the Server Detail Screen with updated data
-        expect(
-          find.text('Updated TrueNAS Server'),
-          findsOneWidget,
-        ); // Navigation bar should show updated name
-
-        // Wait for any potential async operations to complete
-        await tester.pump(const Duration(milliseconds: 100));
-
-        // STEP 7: Verify core changes have bubbled up to the provider
-        expect(serverProvider.selectedServer, isNotNull);
-        expect(serverProvider.selectedServer?.name, 'Updated TrueNAS Server');
-        // Host should remain unchanged since we only tested name change
-        expect(serverProvider.selectedServer?.host, '192.168.1.100');
-
-        // Note: Skip complex field verifications in e2e test as they are covered in unit tests
-        // The key is that the basic edit flow works
-
-        // STEP 8: Verify core changes are persisted in the database
-        final serverFromDb = await database.getServer(testServer.id);
-        expect(serverFromDb, isNotNull);
-        expect(serverFromDb!.name, 'Updated TrueNAS Server');
-        expect(serverFromDb.host, '192.168.1.100');
-
-        // STEP 9: Verify the server list in provider is also updated
-        final serversInProvider = serverProvider.servers;
-        final updatedServerInList = serversInProvider.firstWhere(
-          (s) => s.id == testServer.id,
-        );
-        expect(updatedServerInList.name, 'Updated TrueNAS Server');
-        expect(updatedServerInList.host, '192.168.1.100');
-
-        // End of test - we've verified the core edit flow works
-      },
-    );
-
-    testWidgets(
-      'should handle edit cancellation without affecting provider state',
-      (WidgetTester tester) async {
-        Widget createTestApp() {
-          return MultiProvider(
-            providers: [
-              Provider<AppDatabase>.value(value: database),
-              Provider<UnifiedServerService>.value(value: unifiedServerService),
-              ChangeNotifierProvider.value(value: serverProvider),
-              ChangeNotifierProvider.value(value: poolProvider),
-              ChangeNotifierProvider(
-                create: (_) => AppProvider(
-                  database: database,
-                  serverService: unifiedServerService,
-                ),
-              ),
-              ChangeNotifierProvider(
-                create: (_) => SystemStatsProvider(unifiedServerService),
-              ),
-              ChangeNotifierProvider(create: (_) => ConnectionStatusProvider()),
-            ],
-            child: const CupertinoApp(home: HomeScreen()),
-          );
-        }
-
-        await tester.pumpWidget(createTestApp());
-
-        // Wait for initial build with timeout protection
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-
-        // Navigate to server detail
-        await tester.tap(find.text('Test TrueNAS Server'));
-        // Wait for navigation to complete without pumpAndSettle
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
-
-        // Extra wait for async operations in ServerDetailScreen
-        await tester.pump(const Duration(milliseconds: 500));
-
-        // Store original server state
-        final originalServer = serverProvider.selectedServer!;
-        expect(originalServer.name, 'Test TrueNAS Server');
-        expect(originalServer.host, '192.168.1.100');
-        expect(originalServer.allowUntrustedCertificates, isFalse);
-
-        // Navigate to edit screen
-        final ellipsisButton = find.byIcon(CupertinoIcons.ellipsis);
-        expect(ellipsisButton, findsOneWidget);
-
-        await tester.tap(ellipsisButton);
-        await tester.pump(const Duration(milliseconds: 100)); // Start animation
-        await tester.pump(
-          const Duration(milliseconds: 300),
-        ); // Complete animation
-
-        // Verify action sheet appeared
-        expect(find.byType(CupertinoActionSheet), findsOneWidget);
-        expect(find.text('Edit Server'), findsOneWidget);
-
-        await tester.tap(find.text('Edit Server'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
-
-        // Make changes
-        final nameFields = find.byType(CupertinoTextField);
-        await tester.enterText(nameFields.first, 'Changed Server Name');
-        await tester.pump(const Duration(milliseconds: 100));
-
-        // Cancel instead of saving
-        await tester.tap(find.text('Cancel'));
-        // Use pump with duration for navigation
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
-
-        // Verify we're back on server detail screen with original data
-        expect(find.text('Test TrueNAS Server'), findsOneWidget);
-
-        // Verify provider state is unchanged
-        expect(serverProvider.selectedServer?.name, 'Test TrueNAS Server');
-        expect(serverProvider.selectedServer?.host, '192.168.1.100');
-        expect(
-          serverProvider.selectedServer?.allowUntrustedCertificates,
-          isFalse,
-        );
-
-        // Verify database is unchanged
-        final serverFromDb = await database.getServer(testServer.id);
-        expect(serverFromDb!.name, 'Test TrueNAS Server');
-        expect(serverFromDb.host, '192.168.1.100');
-        expect(serverFromDb.allowUntrustedCertificates, isFalse);
-      },
-    );
+      final serverFromDb = await runRealAsync(
+        tester,
+        () => database.getServer(testServer.id),
+      );
+      expect(serverFromDb, isNotNull);
+      expect(serverFromDb!.name, 'Test TrueNAS Server');
+      expect(serverFromDb.host, '192.168.1.100');
+      expect(serverFromDb.allowUntrustedCertificates, isFalse);
+    });
 
     testWidgets('should handle multiple consecutive edits correctly', (
       WidgetTester tester,
     ) async {
-      Widget createTestApp() {
-        return MultiProvider(
-          providers: [
-            Provider<AppDatabase>.value(value: database),
-            ChangeNotifierProvider.value(value: serverProvider),
-            ChangeNotifierProvider.value(value: poolProvider),
-          ],
-          child: const CupertinoApp(home: HomeScreen()),
-        );
-      }
+      await pumpHomeScreen(tester);
+      await openServerDetail(tester);
+      await pumpUntilAsync(tester, () => serverProvider.selectedServer != null);
 
-      await tester.pumpWidget(createTestApp());
-
-      // Wait for initial build with timeout protection
+      // First edit: change the name.
+      await openEditScreen(tester);
+      await tester.enterText(formFieldWithLabel('Name'), 'First Edit');
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+      await tapWhenUnambiguous(tester, find.text('Save'));
+      await pumpUntilAsync(
+        tester,
+        () => serverProvider.selectedServer?.name == 'First Edit',
+      );
 
-      // Navigate to server detail
-      await tester.tap(find.text('Test TrueNAS Server'));
-      // Wait for navigation to complete without pumpAndSettle
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pump(const Duration(milliseconds: 300));
-
-      // Extra wait for async operations in ServerDetailScreen
-      await tester.pump(const Duration(milliseconds: 500));
-
-      // First edit: Change name
-      final ellipsisButton = find.byIcon(CupertinoIcons.ellipsis);
-      expect(ellipsisButton, findsOneWidget);
-
-      await tester.tap(ellipsisButton);
-      await tester.pump(const Duration(milliseconds: 100)); // Start animation
-      await tester.pump(
-        const Duration(milliseconds: 300),
-      ); // Complete animation
-
-      // Verify action sheet appeared
-      expect(find.byType(CupertinoActionSheet), findsOneWidget);
-      expect(find.text('Edit Server'), findsOneWidget);
-
-      await tester.tap(find.text('Edit Server'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pump(const Duration(milliseconds: 300));
-
-      final nameFields = find.byType(CupertinoTextField);
-      await tester.enterText(nameFields.first, 'First Edit');
-      await tester.pump(const Duration(milliseconds: 100));
-      await tester.tap(find.text('Save'));
-      // Use pump with duration for navigation
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pump(const Duration(milliseconds: 300));
-
-      // Verify first change
-      expect(find.text('First Edit'), findsOneWidget);
       expect(serverProvider.selectedServer?.name, 'First Edit');
 
-      // Second edit: Toggle HTTPS and change port
-      final ellipsisButton2 = find.byIcon(CupertinoIcons.ellipsis);
-      expect(ellipsisButton2, findsOneWidget);
-
-      await tester.tap(ellipsisButton2);
-      await tester.pump(const Duration(milliseconds: 100)); // Start animation
-      await tester.pump(
-        const Duration(milliseconds: 300),
-      ); // Complete animation
-
-      // Verify action sheet appeared
-      expect(find.byType(CupertinoActionSheet), findsOneWidget);
-      expect(find.text('Edit Server'), findsOneWidget);
-
-      await tester.tap(find.text('Edit Server'));
+      // Second edit: change the host, on top of the first change.
+      await openEditScreen(tester);
+      await tester.enterText(formFieldWithLabel('Host'), '10.0.0.5');
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pump(const Duration(milliseconds: 300));
+      await tapWhenUnambiguous(tester, find.text('Save'));
+      await pumpUntilAsync(
+        tester,
+        () => serverProvider.selectedServer?.host == '10.0.0.5',
+      );
 
-      // Toggle HTTPS off
-      // First scroll to ensure it's visible
-      await tester.drag(find.byType(ListView), const Offset(0, -200));
-      await tester.pump(const Duration(milliseconds: 100));
-
-      final httpsRow = find.text('Use HTTPS');
-      if (httpsRow.evaluate().isNotEmpty) {
-        final httpsToggle = find.descendant(
-          of: find.ancestor(
-            of: httpsRow,
-            matching: find.byType(CupertinoFormRow),
-          ),
-          matching: find.byType(CupertinoSwitch),
-        );
-
-        if (httpsToggle.evaluate().isNotEmpty) {
-          await tester.tap(httpsToggle);
-        }
-      }
-      await tester.pump(const Duration(milliseconds: 100));
-
-      // Save second edit
-      await tester.tap(find.text('Save'));
-      // Use pump with duration for navigation
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pump(const Duration(milliseconds: 300));
-
-      // Verify both changes are reflected
-      expect(find.text('First Edit'), findsOneWidget);
+      // Both edits survived.
       expect(serverProvider.selectedServer?.name, 'First Edit');
-      expect(serverProvider.selectedServer?.useHttps, isFalse);
+      expect(serverProvider.selectedServer?.host, '10.0.0.5');
 
-      // Verify changes are persisted
-      final finalServer = await database.getServer(testServer.id);
+      final finalServer = await runRealAsync(
+        tester,
+        () => database.getServer(testServer.id),
+      );
+      expect(finalServer, isNotNull);
       expect(finalServer!.name, 'First Edit');
-      expect(finalServer.useHttps, isFalse);
+      expect(finalServer.host, '10.0.0.5');
     });
   });
 }

--- a/test/helpers/form_finders.dart
+++ b/test/helpers/form_finders.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Finders for the Cupertino form rows used across the server screens.
+///
+/// The screens build their inputs with [CupertinoTextFormFieldRow] and label
+/// them through the row's `prefix`. Addressing fields by that label keeps tests
+/// readable and, more importantly, stable: positional lookups such as
+/// `find.byType(CupertinoTextField).first` silently start editing a different
+/// field as soon as a row is added or reordered.
+
+/// The form row carrying [label] as its prefix.
+Finder formRowWithLabel(String label) {
+  return find.ancestor(
+    of: find.text(label),
+    matching: find.byType(CupertinoTextFormFieldRow),
+  );
+}
+
+/// The editable text of the form row labelled [label].
+///
+/// Pass this to [WidgetTester.enterText], which needs the [EditableText]
+/// itself rather than one of its ancestors.
+Finder formFieldWithLabel(String label) {
+  return find.descendant(
+    of: formRowWithLabel(label),
+    matching: find.byType(EditableText),
+  );
+}

--- a/test/helpers/pump_helpers.dart
+++ b/test/helpers/pump_helpers.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pumping utilities for widget tests.
+///
+/// Large parts of the app render an indefinite [CupertinoActivityIndicator]
+/// while a server connection is being authenticated. `pumpAndSettle` never
+/// returns in that situation because the animation never stops, which is why
+/// the widget tests in this repository must not use it.
+///
+/// The helpers below pump a bounded number of frames and stop as soon as a
+/// condition holds, which gives the same intent as `pumpAndSettle` without the
+/// risk of hanging the whole test file.
+
+/// The default budget a single [pumpUntil] call may spend.
+const Duration kPumpUntilTimeout = Duration(seconds: 5);
+
+/// The amount of virtual time advanced per pumped frame.
+const Duration kPumpStep = Duration(milliseconds: 50);
+
+/// Pumps frames until [condition] returns `true`, or until [timeout] of
+/// virtual time has been consumed.
+///
+/// Returns `true` when [condition] became satisfied and `false` when the
+/// timeout was hit. Callers that require the condition should assert on the
+/// widget tree afterwards so the failure message points at the real problem.
+Future<bool> pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  Duration timeout = kPumpUntilTimeout,
+  Duration step = kPumpStep,
+}) async {
+  if (condition()) {
+    return true;
+  }
+
+  var elapsed = Duration.zero;
+  while (elapsed < timeout) {
+    await tester.pump(step);
+    elapsed += step;
+    if (condition()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Pumps until [finder] matches at least one widget.
+Future<bool> pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = kPumpUntilTimeout,
+  Duration step = kPumpStep,
+}) {
+  return pumpUntil(
+    tester,
+    () => finder.evaluate().isNotEmpty,
+    timeout: timeout,
+    step: step,
+  );
+}
+
+/// Pumps until [finder] matches exactly one widget.
+///
+/// Cupertino route transitions temporarily render a second copy of the
+/// navigation bar so its contents can be animated between routes. Tapping
+/// during that window fails with an "ambiguously found multiple matching
+/// widgets" error, so tests must wait for the transition to finish before
+/// interacting with navigation bar items.
+Future<bool> pumpUntilExactlyOne(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = kPumpUntilTimeout,
+  Duration step = kPumpStep,
+}) {
+  return pumpUntil(
+    tester,
+    () => finder.evaluate().length == 1,
+    timeout: timeout,
+    step: step,
+  );
+}
+
+/// Waits for [finder] to resolve to exactly one widget and taps it.
+///
+/// This is the safe replacement for `await tester.tap(find.text('Save'))`
+/// directly after a navigation, where the target may still be duplicated by an
+/// in-flight route transition.
+Future<void> tapWhenUnambiguous(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = kPumpUntilTimeout,
+  Duration step = kPumpStep,
+}) async {
+  final settled = await pumpUntilExactlyOne(
+    tester,
+    finder,
+    timeout: timeout,
+    step: step,
+  );
+  expect(
+    settled,
+    isTrue,
+    reason:
+        'Expected exactly one widget for $finder within $timeout, '
+        'found ${finder.evaluate().length}',
+  );
+  await tester.tap(finder);
+  await tester.pump();
+  await tester.pump(kPumpStep);
+}
+
+/// Pumps enough frames for a pushed or popped route to finish animating.
+///
+/// Cupertino page transitions run for well under a second; the extra budget
+/// covers the post-frame callbacks the screens use to load their data.
+Future<void> settleRouteTransition(
+  WidgetTester tester, {
+  Duration duration = const Duration(milliseconds: 800),
+  Duration step = kPumpStep,
+}) async {
+  var elapsed = Duration.zero;
+  while (elapsed < duration) {
+    await tester.pump(step);
+    elapsed += step;
+  }
+}
+
+/// The real-time slice granted per iteration of [pumpUntilAsync].
+const Duration kRealAsyncStep = Duration(milliseconds: 20);
+
+/// Pumps until [condition] holds, while letting *real* asynchronous work make
+/// progress between frames.
+///
+/// `testWidgets` runs its body inside a `FakeAsync` zone, where only timers
+/// driven by [WidgetTester.pump] advance. Anything backed by the real event
+/// loop — drift queries against `NativeDatabase`, keychain calls, platform
+/// channels — never completes there, so a screen that saves to the database
+/// simply stalls and the test observes nothing happening.
+///
+/// [WidgetTester.runAsync] steps outside the fake zone and lets that work run.
+/// Interleaving it with [WidgetTester.pump] gives both the widget animations
+/// and the real futures a chance to progress.
+///
+/// Use this instead of [pumpUntil] whenever the awaited effect crosses the
+/// database, the keychain or a platform channel.
+Future<bool> pumpUntilAsync(
+  WidgetTester tester,
+  bool Function() condition, {
+  Duration timeout = kPumpUntilTimeout,
+  Duration step = kRealAsyncStep,
+}) async {
+  if (condition()) {
+    return true;
+  }
+
+  var elapsed = Duration.zero;
+  while (elapsed < timeout) {
+    await tester.runAsync(() => Future<void>.delayed(step));
+    await tester.pump(step);
+    elapsed += step;
+    if (condition()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Runs [action] outside the `FakeAsync` zone and pumps a frame afterwards.
+///
+/// Wrap every direct database access made from inside a `testWidgets` body in
+/// this, otherwise the returned future never completes.
+Future<T?> runRealAsync<T>(
+  WidgetTester tester,
+  Future<T> Function() action,
+) async {
+  final result = await tester.runAsync(action);
+  await tester.pump();
+  return result;
+}

--- a/test/helpers/test_providers.dart
+++ b/test/helpers/test_providers.dart
@@ -64,14 +64,21 @@ class TestProviders {
   /// forever. Without the guard a single failing test wedges every remaining
   /// test in the same file, which is exactly how a CI run turns into a one-hour
   /// timeout instead of a readable failure.
+  /// Every notifier the test created itself belongs in [providers]. Injecting
+  /// one with `ChangeNotifierProvider.value` hands the widget tree a borrowed
+  /// reference: the provider does not own it and never disposes it, so the
+  /// test has to. Missing one leaks whatever it holds - a `PoolProvider`, for
+  /// instance, keeps an API client checked out until `dispose` releases it.
   static Future<void> disposeTestStack({
-    ChangeNotifier? provider,
+    Iterable<ChangeNotifier> providers = const [],
     UnifiedServerService? service,
     AppDatabase? database,
     Duration timeout = const Duration(seconds: 5),
   }) async {
     await _ignoringErrors(cleanupTestEnvironment);
-    await _ignoringErrors(() async => provider?.dispose());
+    for (final provider in providers) {
+      await _ignoringErrors(() async => provider.dispose());
+    }
     await _ignoringErrors(() async => service?.dispose());
 
     if (database != null) {

--- a/test/helpers/test_providers.dart
+++ b/test/helpers/test_providers.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
 import 'package:truehub/services/sqlite_server_repository.dart';
+import 'package:flutter/foundation.dart';
 import 'package:truehub/providers/server_provider.dart';
 import 'package:truehub/services/api_client_manager.dart';
 import 'package:truenas_native_plugins/truenas_native_plugins.dart'
@@ -48,6 +51,41 @@ class TestProviders {
   static void setupTestEnvironment() {
     // Set the mock API client manager
     ApiClientManager.setInstance(mockApiClientManager);
+  }
+
+  /// Tears down the full test stack in the correct order.
+  ///
+  /// The order matters: static state first, then the provider, then the
+  /// service, and only afterwards the database.
+  ///
+  /// [AppDatabase.close] is guarded by [timeout] on purpose. When a widget test
+  /// fails part way through, drift queries that were started inside the test's
+  /// `FakeAsync` zone can never complete, and `close()` then waits for them
+  /// forever. Without the guard a single failing test wedges every remaining
+  /// test in the same file, which is exactly how a CI run turns into a one-hour
+  /// timeout instead of a readable failure.
+  static Future<void> disposeTestStack({
+    ChangeNotifier? provider,
+    UnifiedServerService? service,
+    AppDatabase? database,
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    await _ignoringErrors(cleanupTestEnvironment);
+    await _ignoringErrors(() async => provider?.dispose());
+    await _ignoringErrors(() async => service?.dispose());
+
+    if (database != null) {
+      await _ignoringErrors(() => database.close().timeout(timeout));
+    }
+  }
+
+  static Future<void> _ignoringErrors(Future<void> Function() action) async {
+    try {
+      await action();
+    } catch (_) {
+      // Teardown is best effort: a failure here must never mask the actual
+      // test failure, and must never stop the remaining teardown steps.
+    }
   }
 
   /// Cleans up all static state that might interfere with test isolation

--- a/test/screens/edit_server_screen_simplified_test.dart
+++ b/test/screens/edit_server_screen_simplified_test.dart
@@ -9,6 +9,7 @@ import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
 import '../helpers/test_providers.dart';
 import '../helpers/mock_network_service.dart';
+import '../helpers/pump_helpers.dart';
 
 void main() {
   late AppDatabase database;
@@ -47,63 +48,47 @@ void main() {
   });
 
   tearDown(() async {
-    try {
-      // Clean up any static state first
-      await TestProviders.cleanupTestEnvironment();
-
-      // Dispose providers
-      serverProvider.dispose();
-      unifiedServerService.dispose();
-
-      // Close database
-      await database.close();
-    } catch (e) {
-      // Ignore teardown errors in test environment
-    }
+    await TestProviders.disposeTestStack(
+      provider: serverProvider,
+      service: unifiedServerService,
+      database: database,
+    );
   });
 
   group('EditServerScreen Core Functionality', () {
-    testWidgets(
-      'should display edit server screen',
-      skip:
-          true, // Still investigating hanging issue - may be related to database or provider lifecycle
-      (WidgetTester tester) async {
-        // Ensure clean state
-        await TestProviders.cleanupTestEnvironment();
-
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: MultiProvider(
-              providers: [
-                Provider<AppDatabase>.value(value: database),
-                Provider<UnifiedServerService>.value(
-                  value: unifiedServerService,
-                ),
-                ChangeNotifierProvider.value(value: serverProvider),
-              ],
-              child: EditServerScreen(
-                server: testServer,
-                networkService: mockNetworkService,
-              ),
+    testWidgets('should display edit server screen', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: MultiProvider(
+            providers: [
+              Provider<AppDatabase>.value(value: database),
+              Provider<UnifiedServerService>.value(value: unifiedServerService),
+              ChangeNotifierProvider.value(value: serverProvider),
+            ],
+            child: EditServerScreen(
+              server: testServer,
+              networkService: mockNetworkService,
             ),
           ),
-        );
+        ),
+      );
 
-        // Pump once to build the widget
-        await tester.pump();
+      // Pump once to build the widget
+      await tester.pump();
 
-        // Wait for the post-frame callback to execute
-        await tester.pump(const Duration(milliseconds: 50));
+      // Wait for the post-frame callback to execute
+      await tester.pump(const Duration(milliseconds: 50));
 
-        // Wait for credential loading to complete
-        await tester.pump(const Duration(milliseconds: 200));
+      // Wait for credential loading to complete
+      await tester.pump(const Duration(milliseconds: 200));
 
-        // Check that the edit screen is displayed
-        expect(find.text('Edit Server'), findsOneWidget);
-        expect(find.text('Save'), findsOneWidget);
-        expect(find.text('Cancel'), findsOneWidget);
-      },
-    );
+      // Check that the edit screen is displayed
+      expect(find.text('Edit Server'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
 
     testWidgets('should save server changes and return true', (
       WidgetTester tester,
@@ -154,10 +139,14 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
-      // Save without making changes (should still return true)
-      await tester.tap(find.text('Save'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+      // The Cupertino navigation bar renders a second copy of its contents
+      // while the push transition runs, so wait for it to settle before
+      // tapping. Save without making changes should still return true.
+      await tapWhenUnambiguous(tester, find.text('Save'));
+
+      // Saving writes through to the database, which only makes progress
+      // outside the FakeAsync zone.
+      await pumpUntilAsync(tester, () => navigationResult != null);
 
       expect(navigationResult, isTrue);
     });
@@ -211,64 +200,65 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
-      // Cancel the edit
-      await tester.tap(find.text('Cancel'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+      // Cancel the edit once the push transition stopped duplicating the
+      // navigation bar contents.
+      await tapWhenUnambiguous(tester, find.text('Cancel'));
+      await settleRouteTransition(tester);
 
       expect(navigationResult, isNull);
     });
 
-    testWidgets(
-      'should update server in database when saved',
-      skip:
-          true, // Still investigating hanging issue - may be related to database or provider lifecycle
-      (WidgetTester tester) async {
-        // Ensure clean state
-        await TestProviders.cleanupTestEnvironment();
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: MultiProvider(
-              providers: [
-                Provider<AppDatabase>.value(value: database),
-                Provider<UnifiedServerService>.value(
-                  value: unifiedServerService,
-                ),
-                ChangeNotifierProvider.value(value: serverProvider),
-              ],
-              child: EditServerScreen(
-                server: testServer,
-                networkService: mockNetworkService,
-              ),
+    testWidgets('should update server in database when saved', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: MultiProvider(
+            providers: [
+              Provider<AppDatabase>.value(value: database),
+              Provider<UnifiedServerService>.value(value: unifiedServerService),
+              ChangeNotifierProvider.value(value: serverProvider),
+            ],
+            child: EditServerScreen(
+              server: testServer,
+              networkService: mockNetworkService,
             ),
           ),
-        );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
-        // Extra delay to let _loadExistingCredentials complete
-        await tester.pump(const Duration(milliseconds: 300));
+      // Extra delay to let _loadExistingCredentials complete
+      await tester.pump(const Duration(milliseconds: 300));
 
-        // Find and update the server name field
-        final nameFields = find.byType(CupertinoTextField);
-        expect(nameFields, findsWidgets);
+      // Find and update the server name field
+      final nameFields = find.byType(CupertinoTextField);
+      expect(nameFields, findsWidgets);
 
-        // Assuming the first text field is the name field based on the UI structure
-        await tester.enterText(nameFields.first, 'Updated Server Name');
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+      // Assuming the first text field is the name field based on the UI structure
+      await tester.enterText(nameFields.first, 'Updated Server Name');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
-        // Save the changes
-        await tester.tap(find.text('Save'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+      // Save the changes and wait for the write to land.
+      await tapWhenUnambiguous(tester, find.text('Save'));
+      await pumpUntilAsync(
+        tester,
+        () => serverProvider.servers.any(
+          (s) => s.id == testServer.id && s.name == 'Updated Server Name',
+        ),
+      );
 
-        // Verify the server was updated in the database
-        final updatedServer = await database.getServer(testServer.id);
-        expect(updatedServer, isNotNull);
-        expect(updatedServer!.name, 'Updated Server Name');
-      },
-    );
+      // Verify the server was updated in the database. The read has to leave
+      // the FakeAsync zone, otherwise the drift future never completes.
+      final updatedServer = await runRealAsync(
+        tester,
+        () => database.getServer(testServer.id),
+      );
+      expect(updatedServer, isNotNull);
+      expect(updatedServer!.name, 'Updated Server Name');
+    });
   });
 
   group('Server Provider Integration', () {
@@ -300,10 +290,12 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
-      // Save changes
-      await tester.tap(find.text('Save'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+      // Save changes and wait for the write to reach the provider.
+      await tapWhenUnambiguous(tester, find.text('Save'));
+      await pumpUntilAsync(
+        tester,
+        () => serverProvider.selectedServer?.name == 'Provider Updated Server',
+      );
 
       // Verify the selected server was refreshed in the provider
       expect(serverProvider.selectedServer?.name, 'Provider Updated Server');
@@ -335,10 +327,32 @@ void main() {
       expect(serverFromDb.trustedWifiSsids, ['WiFi1', 'WiFi2']);
       expect(serverFromDb.port, 8443);
       expect(serverFromDb.username, 'newuser');
-      expect(serverFromDb.password, 'newpassword');
       expect(serverFromDb.useHttps, isTrue);
       expect(serverFromDb.allowUntrustedCertificates, isTrue);
+
+      // Passwords are deliberately not persisted in the database - they live
+      // in the keychain and are only written when passed explicitly.
+      expect(serverFromDb.password, isEmpty);
     });
+
+    test(
+      'should store an updated password in the keychain, not the database',
+      () async {
+        await serverProvider.updateServer(
+          testServer.copyWith(name: 'Keychain Test Server'),
+          password: 'newpassword',
+        );
+
+        expect(
+          await unifiedServerService.getPassword(testServer.id),
+          'newpassword',
+        );
+
+        final serverFromDb = await database.getServer(testServer.id);
+        expect(serverFromDb, isNotNull);
+        expect(serverFromDb!.password, isEmpty);
+      },
+    );
 
     test('should refresh selected server after database update', () async {
       // Select the test server

--- a/test/screens/edit_server_screen_simplified_test.dart
+++ b/test/screens/edit_server_screen_simplified_test.dart
@@ -49,7 +49,7 @@ void main() {
 
   tearDown(() async {
     await TestProviders.disposeTestStack(
-      provider: serverProvider,
+      providers: [serverProvider],
       service: unifiedServerService,
       database: database,
     );
@@ -155,6 +155,10 @@ void main() {
       WidgetTester tester,
     ) async {
       bool? navigationResult;
+      // `navigationResult` is null both before the route is pushed and after a
+      // cancel, so on its own it cannot tell a successful cancel from a Cancel
+      // button that never popped. This flag records that the route completed.
+      var navigationCompleted = false;
 
       await tester.pumpWidget(
         CupertinoApp(
@@ -186,6 +190,7 @@ void main() {
                           ),
                         ),
                       );
+                  navigationCompleted = true;
                 },
               ),
             ),
@@ -203,9 +208,15 @@ void main() {
       // Cancel the edit once the push transition stopped duplicating the
       // navigation bar contents.
       await tapWhenUnambiguous(tester, find.text('Cancel'));
-      await settleRouteTransition(tester);
+      await pumpUntil(tester, () => navigationCompleted);
 
+      expect(
+        navigationCompleted,
+        isTrue,
+        reason: 'Cancel should pop the edit screen',
+      );
       expect(navigationResult, isNull);
+      expect(find.text('Edit'), findsOneWidget);
     });
 
     testWidgets('should update server in database when saved', (


### PR DESCRIPTION
CI has been red on `main` since July 2025 and every run burned the full runner budget instead of reporting a failure. This gets it green again and clears the backlog that had piled up behind it.

## Why the suite was red

`flutter analyze` and `dart format` were both clean — the failures were all in the tests, and three separate problems were tangled together:

1. **Drift futures never complete inside `testWidgets`.** Widget tests run in a `FakeAsync` zone where only timers advanced by `pump()` fire. Anything backed by the real event loop stalls there, so saving from `EditServerScreen` never reached the database, the `Navigator.pop(context, true)` never happened, and the assertions saw nothing.
2. **A failing test wedged everything after it.** Because those futures stayed pending, `await database.close()` in `tearDown` waited for them forever. `flutter test --timeout=30s` does not cover a stuck teardown, so one failure stalled the rest of the file — which is why the job ran for 63 minutes and ended in a timeout rather than a readable failure.
3. **Two assertions had gone stale.** The e2e test still expected the `Host` / `Port` / `Protocol` / `Username` rows that `ServerDetailScreen` lost when its widgets were extracted in #40, and a database test still expected the plaintext password in the server row although credentials moved to the keychain in #38.

## Changes

**Tests**
- New `test/helpers/pump_helpers.dart`: `pumpUntil`, `pumpUntilAsync`, `runRealAsync`, `tapWhenUnambiguous`, `settleRouteTransition`. `pumpUntilAsync` and `runRealAsync` step outside the fake zone via `WidgetTester.runAsync` so database and keychain work actually runs. `pumpAndSettle` remains unusable here because the authentication placeholder animates indefinitely; the helpers are the bounded alternative.
- `tapWhenUnambiguous` fixes the "ambiguously found multiple matching widgets" failures: a Cupertino route transition renders a second copy of the navigation bar, so tapping `Save` mid-transition hit two widgets.
- New `test/helpers/form_finders.dart`: addresses form fields by their label instead of `find.byType(CupertinoTextField).first`, which silently edits a different field as soon as a row is reordered.
- `TestProviders.disposeTestStack` tears the stack down in order and guards `database.close()` with a timeout, so a pending future can no longer wedge a whole file.
- The e2e test's three copies of the provider setup are replaced by one builder plus small `pumpHomeScreen` / `openServerDetail` / `openEditScreen` steps.
- Re-enabled the two `EditServerScreen` tests that were skipped as *"still investigating hanging issue"*, and corrected the stale assertions — the password one now explicitly asserts the database does **not** hold the secret.

**Dependencies**
- One resolution picks up the pending Dependabot bumps: drift and drift_dev 2.29.0, drift_flutter 0.2.7, flutter_slidable 4.0.3, fl_chart 1.1.0, build_runner 2.7.1, tray_manager 0.5.3, dio 5.11.0, connectivity_plus 7.3.1, plus transitives. This should close #64, #68, #70, #75, #76, #77, #80, #81 and #82.
- The newer analyzer enables `use_null_aware_elements`, which flagged the optional OTP token in the `auth.login` argument list; rewritten to the null-aware element form.
- `dart_pre_commit` stops at 5.4.7 — 6.0.0 needs Dart >= 3.9.0, i.e. a newer Flutter than the pinned 3.32.6. See below.

**CI**
- Added `timeout-minutes: 45` so a hang fails fast instead of consuming the runner limit.

**Docs**
- README and CLAUDE.md listed API integration, file browsing and health monitoring as "in progress" although all three shipped long ago. Both now reflect what is actually in the tree, with the planned items linked to their issues.

## Verification

Run locally against Flutter 3.32.6, the version the workflow pins:

- `dart run build_runner build --delete-conflicting-outputs` — clean
- `flutter analyze` — no issues
- `dart format --set-exit-if-changed .` — no changes
- `flutter test` — **144 passed in 26s** (previously: 2 failures, 6 tests never completing, and a 63-minute job)

## Not done here

- **The Flutter pin is untouched.** It turned out not to be the cause of the failure, and bumping it also moves the `flutter build ios` / `flutter build macos` steps, which cannot be verified on Linux. That upgrade — and `dart_pre_commit` 6.0.0 with it (#74) — wants its own change on a macOS runner.
- The iOS and macOS build steps in this PR are likewise unverified locally for the same reason; CI is the first place they run.

Closes #48 is already handled separately (the issue was closed as completed — the extraction landed in #53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5z1S7zDW147LN1x38h9b1

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5z1S7zDW147LN1x38h9b1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated product documentation to reflect secure storage, synchronization, app management, storage browsing, menu bar integration, and current feature status.
  - Clarified supported Flutter SDK requirements.

- **Bug Fixes**
  - Improved login handling when no one-time password is provided.

- **Tests**
  - Expanded coverage for editing, cancellation, persistence, navigation, and secure password storage.
  - Improved reliability of asynchronous and end-to-end testing.

- **Chores**
  - Added a timeout for macOS CI runs to prevent stalled jobs.
  - Updated connectivity and development tooling packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->