### PR TITLE
chore: upgrade to Flutter 3.47.2 / Dart 3.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Single source of truth: the SDK the job installs and the key its cache is
+  # scoped to must never drift apart.
+  FLUTTER_VERSION: '3.47.2'
+
 jobs:
   test:
     permissions:
@@ -27,7 +32,7 @@ jobs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.47.2'
+        flutter-version: ${{ env.FLUTTER_VERSION }}
         channel: 'stable'
         cache: true
 
@@ -38,9 +43,12 @@ jobs:
           ~/.pub-cache
           **/.dart_tool
           **/build
-        key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+        # .dart_tool and build hold SDK-specific artifacts, so the key and the
+        # fallback both carry the Flutter version. Without it, a cache written
+        # by an older SDK would be restored into a newer one's build.
+        key: ${{ runner.os }}-flutter-${{ env.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock') }}
         restore-keys: |
-          ${{ runner.os }}-flutter-
+          ${{ runner.os }}-flutter-${{ env.FLUTTER_VERSION }}-
 
     - name: Get dependencies
       run: flutter pub get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.32.6'
+        flutter-version: '3.47.2'
         channel: 'stable'
         cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,17 @@ jobs:
     - name: Cache dependencies
       uses: actions/cache@v4
       with:
+        # build/ is deliberately not cached. It holds Xcode's precompiled Swift
+        # modules, which are bound to the exact FlutterMacOS.framework headers
+        # they were built against. Restoring them across a toolchain change
+        # fails the macOS build with "has been modified since the module file
+        # was built" - and the runner's Xcode can move without any key of ours
+        # changing, so scoping alone would not be enough.
         path: |
           ~/.pub-cache
           **/.dart_tool
-          **/build
-        # .dart_tool and build hold SDK-specific artifacts, so the key and the
-        # fallback both carry the Flutter version. Without it, a cache written
-        # by an older SDK would be restored into a newer one's build.
+        # .dart_tool is SDK-specific too, so the key and the fallback both carry
+        # the Flutter version.
         key: ${{ runner.os }}-flutter-${{ env.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock') }}
         restore-keys: |
           ${{ runner.os }}-flutter-${{ env.FLUTTER_VERSION }}-

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The app follows a clean architecture pattern with:
 
 ### Prerequisites
 
-- Flutter SDK 3.32.6 or newer (bundles Dart 3.8.1, which `pubspec.yaml` requires)
+- Flutter SDK 3.47.2 or newer (bundles Dart 3.13.2; `pubspec.yaml` requires Dart 3.9.0+)
 - Xcode (for iOS/macOS development)
 - CocoaPods
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,11 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - ios/**
+    - macos/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,31 +11,6 @@ PODS:
     - Flutter
   - permission_handler_apple (9.4.8):
     - Flutter
-  - sqlite3 (3.52.0):
-    - sqlite3/common (= 3.52.0)
-  - sqlite3/common (3.52.0)
-  - sqlite3/dbstatvtab (3.52.0):
-    - sqlite3/common
-  - sqlite3/fts5 (3.52.0):
-    - sqlite3/common
-  - sqlite3/math (3.52.0):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.52.0):
-    - sqlite3/common
-  - sqlite3/rtree (3.52.0):
-    - sqlite3/common
-  - sqlite3/session (3.52.0):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.52.0)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
   - truenas_native_plugins (0.1.0):
     - Flutter
   - url_launcher_ios (0.0.1):
@@ -48,13 +23,8 @@ DEPENDENCIES:
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - network_info_plus (from `.symlinks/plugins/network_info_plus/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
-  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - truenas_native_plugins (from `.symlinks/plugins/truenas_native_plugins/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-
-SPEC REPOS:
-  trunk:
-    - sqlite3
 
 EXTERNAL SOURCES:
   connectivity_plus:
@@ -69,8 +39,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/network_info_plus/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
-  sqlite3_flutter_libs:
-    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
   truenas_native_plugins:
     :path: ".symlinks/plugins/truenas_native_plugins/ios"
   url_launcher_ios:
@@ -83,8 +51,6 @@ SPEC CHECKSUMS:
   local_auth_darwin: 63c73d6d28cc3e239be2b6aa460ea6e317cd5100
   network_info_plus: 6613d9d7cdeb0e6f366ed4dbe4b3c51c52d567a9
   permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
-  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
-  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
   truenas_native_plugins: a5e975082bea74e12f3fb60c8b25f201f0e55330
   url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,9 +9,6 @@ PODS:
     - FlutterMacOS
   - network_info_plus (0.0.1):
     - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - permission_handler_apple (9.4.8):
     - Flutter
   - sqlite3 (3.52.0):
@@ -50,7 +47,6 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - network_info_plus (from `.symlinks/plugins/network_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - truenas_native_plugins (from `.symlinks/plugins/truenas_native_plugins/ios`)
@@ -71,8 +67,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   network_info_plus:
     :path: ".symlinks/plugins/network_info_plus/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   sqlite3_flutter_libs:
@@ -84,16 +78,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  local_auth_darwin: fa4b06454df7df8e97c18d7ee55151c57e7af0de
+  local_auth_darwin: 63c73d6d28cc3e239be2b6aa460ea6e317cd5100
   network_info_plus: 6613d9d7cdeb0e6f366ed4dbe4b3c51c52d567a9
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
   sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
   sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
   truenas_native_plugins: a5e975082bea74e12f3fb60c8b25f201f0e55330
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 

--- a/lib/screens/app_detail_screen.dart
+++ b/lib/screens/app_detail_screen.dart
@@ -99,8 +99,8 @@ class _AppDetailScreenState extends State<AppDetailScreen> {
                 ),
                 decoration: BoxDecoration(
                   color: widget.app.installed
-                      ? CupertinoColors.systemGreen.withOpacity(0.1)
-                      : CupertinoColors.systemBlue.withOpacity(0.1),
+                      ? CupertinoColors.systemGreen.withValues(alpha: 0.1)
+                      : CupertinoColors.systemBlue.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
@@ -316,7 +316,7 @@ class _AppDetailScreenState extends State<AppDetailScreen> {
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: CupertinoColors.systemRed.withOpacity(0.1),
+                    color: CupertinoColors.systemRed.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Row(
@@ -424,7 +424,7 @@ class _AppDetailScreenState extends State<AppDetailScreen> {
               child: Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemBlue.withOpacity(0.1),
+                  color: CupertinoColors.systemBlue.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(

--- a/lib/screens/server_detail_screen.dart
+++ b/lib/screens/server_detail_screen.dart
@@ -474,7 +474,7 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
               Container(
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemYellow.withOpacity(0.1),
+                  color: CupertinoColors.systemYellow.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(6),
                 ),
                 child: Row(

--- a/lib/screens/server_pools_screen.dart
+++ b/lib/screens/server_pools_screen.dart
@@ -130,8 +130,8 @@ class _ServerPoolsScreenState extends State<ServerPoolsScreen> {
                 height: 48,
                 decoration: BoxDecoration(
                   color: healthy
-                      ? CupertinoColors.systemGreen.withOpacity(0.1)
-                      : CupertinoColors.systemRed.withOpacity(0.1),
+                      ? CupertinoColors.systemGreen.withValues(alpha: 0.1)
+                      : CupertinoColors.systemRed.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Icon(

--- a/lib/screens/user_profile_screen.dart
+++ b/lib/screens/user_profile_screen.dart
@@ -79,9 +79,11 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
       return Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: CupertinoColors.systemRed.withOpacity(0.1),
+          color: CupertinoColors.systemRed.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: CupertinoColors.systemRed.withOpacity(0.3)),
+          border: Border.all(
+            color: CupertinoColors.systemRed.withValues(alpha: 0.3),
+          ),
         ),
         child: Column(
           children: [
@@ -164,7 +166,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
             width: 80,
             height: 80,
             decoration: BoxDecoration(
-              color: CupertinoColors.activeBlue.withOpacity(0.1),
+              color: CupertinoColors.activeBlue.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(40),
             ),
             child: const Icon(
@@ -200,7 +202,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
                     vertical: 6,
                   ),
                   decoration: BoxDecoration(
-                    color: CupertinoColors.systemOrange.withOpacity(0.1),
+                    color: CupertinoColors.systemOrange.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -232,7 +234,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
                     vertical: 6,
                   ),
                   decoration: BoxDecoration(
-                    color: CupertinoColors.systemGreen.withOpacity(0.1),
+                    color: CupertinoColors.systemGreen.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -319,7 +321,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
               return Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemBlue.withOpacity(0.1),
+                  color: CupertinoColors.systemBlue.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -178,8 +178,14 @@ class AppDatabase extends _$AppDatabase {
         // Credentials are now handled by ServerSyncService
         // Old servers with embedded credentials will be cleaned up
 
-        // Drop the username and password columns
+        // Drop the username and password columns.
+        //
+        // TableMigration is drift's documented API for rewriting a table, and
+        // the only way to drop a column on SQLite. Upstream still marks it
+        // experimental, so the analyzer flags it; this migration already
+        // shipped and cannot change.
         await m.alterTable(
+          // ignore: experimental_member_use
           TableMigration(
             nasServers,
             columnTransformer: {

--- a/lib/services/database.g.dart
+++ b/lib/services/database.g.dart
@@ -760,6 +760,9 @@ class $AppConfigsTable extends AppConfigs
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES nas_servers (id) ON DELETE CASCADE',
+    ),
   );
   static const VerificationMeta _appNameMeta = const VerificationMeta(
     'appName',
@@ -2401,6 +2404,9 @@ class $AppPortConfigsTable extends AppPortConfigs
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES app_configs (id) ON DELETE CASCADE',
+    ),
   );
   static const VerificationMeta _portNumberMeta = const VerificationMeta(
     'portNumber',
@@ -3043,6 +3049,23 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     appConfigs,
     appPortConfigs,
   ];
+  @override
+  StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'nas_servers',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('app_configs', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'app_configs',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('app_port_configs', kind: UpdateKind.delete)],
+    ),
+  ]);
 }
 
 typedef $$NasServersTableCreateCompanionBuilder =
@@ -3077,6 +3100,29 @@ typedef $$NasServersTableUpdateCompanionBuilder =
       Value<bool> isDefault,
       Value<int> rowid,
     });
+
+final class $$NasServersTableReferences
+    extends BaseReferences<_$AppDatabase, $NasServersTable, NasServerData> {
+  $$NasServersTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$AppConfigsTable, List<AppConfigData>>
+  _appConfigsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.appConfigs,
+    aliasName: 'nas_servers__id__app_configs__server_id',
+  );
+
+  $$AppConfigsTableProcessedTableManager get appConfigsRefs {
+    final manager = $$AppConfigsTableTableManager(
+      $_db,
+      $_db.appConfigs,
+    ).filter((f) => f.serverId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_appConfigsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
 
 class $$NasServersTableFilterComposer
     extends Composer<_$AppDatabase, $NasServersTable> {
@@ -3146,6 +3192,31 @@ class $$NasServersTableFilterComposer
     column: $table.isDefault,
     builder: (column) => ColumnFilters(column),
   );
+
+  Expression<bool> appConfigsRefs(
+    Expression<bool> Function($$AppConfigsTableFilterComposer f) f,
+  ) {
+    final $$AppConfigsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.appConfigs,
+      getReferencedColumn: (t) => t.serverId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppConfigsTableFilterComposer(
+            $db: $db,
+            $table: $db.appConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$NasServersTableOrderingComposer
@@ -3268,6 +3339,31 @@ class $$NasServersTableAnnotationComposer
 
   GeneratedColumn<bool> get isDefault =>
       $composableBuilder(column: $table.isDefault, builder: (column) => column);
+
+  Expression<T> appConfigsRefs<T extends Object>(
+    Expression<T> Function($$AppConfigsTableAnnotationComposer a) f,
+  ) {
+    final $$AppConfigsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.appConfigs,
+      getReferencedColumn: (t) => t.serverId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppConfigsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.appConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$NasServersTableTableManager
@@ -3281,12 +3377,9 @@ class $$NasServersTableTableManager
           $$NasServersTableAnnotationComposer,
           $$NasServersTableCreateCompanionBuilder,
           $$NasServersTableUpdateCompanionBuilder,
-          (
-            NasServerData,
-            BaseReferences<_$AppDatabase, $NasServersTable, NasServerData>,
-          ),
+          (NasServerData, $$NasServersTableReferences),
           NasServerData,
-          PrefetchHooks Function()
+          PrefetchHooks Function({bool appConfigsRefs})
         > {
   $$NasServersTableTableManager(_$AppDatabase db, $NasServersTable table)
     : super(
@@ -3360,9 +3453,43 @@ class $$NasServersTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$NasServersTableReferences(db, table, e),
+                ),
+              )
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback: ({appConfigsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (appConfigsRefs) db.appConfigs],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (appConfigsRefs)
+                    await $_getPrefetchedData<
+                      NasServerData,
+                      $NasServersTable,
+                      AppConfigData
+                    >(
+                      currentTable: table,
+                      referencedTable: $$NasServersTableReferences
+                          ._appConfigsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$NasServersTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).appConfigsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.serverId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
         ),
       );
 }
@@ -3377,12 +3504,9 @@ typedef $$NasServersTableProcessedTableManager =
       $$NasServersTableAnnotationComposer,
       $$NasServersTableCreateCompanionBuilder,
       $$NasServersTableUpdateCompanionBuilder,
-      (
-        NasServerData,
-        BaseReferences<_$AppDatabase, $NasServersTable, NasServerData>,
-      ),
+      (NasServerData, $$NasServersTableReferences),
       NasServerData,
-      PrefetchHooks Function()
+      PrefetchHooks Function({bool appConfigsRefs})
     >;
 typedef $$AppConfigsTableCreateCompanionBuilder =
     AppConfigsCompanion Function({
@@ -3451,6 +3575,46 @@ typedef $$AppConfigsTableUpdateCompanionBuilder =
       Value<String?> usedPortsJson,
     });
 
+final class $$AppConfigsTableReferences
+    extends BaseReferences<_$AppDatabase, $AppConfigsTable, AppConfigData> {
+  $$AppConfigsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $NasServersTable _serverIdTable(_$AppDatabase db) =>
+      db.nasServers.createAlias('app_configs__server_id__nas_servers__id');
+
+  $$NasServersTableProcessedTableManager get serverId {
+    final $_column = $_itemColumn<String>('server_id')!;
+
+    final manager = $$NasServersTableTableManager(
+      $_db,
+      $_db.nasServers,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_serverIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static MultiTypedResultKey<$AppPortConfigsTable, List<AppPortConfigData>>
+  _appPortConfigsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.appPortConfigs,
+    aliasName: 'app_configs__id__app_port_configs__app_config_id',
+  );
+
+  $$AppPortConfigsTableProcessedTableManager get appPortConfigsRefs {
+    final manager = $$AppPortConfigsTableTableManager(
+      $_db,
+      $_db.appPortConfigs,
+    ).filter((f) => f.appConfigId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_appPortConfigsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
 class $$AppConfigsTableFilterComposer
     extends Composer<_$AppDatabase, $AppConfigsTable> {
   $$AppConfigsTableFilterComposer({
@@ -3462,11 +3626,6 @@ class $$AppConfigsTableFilterComposer
   });
   ColumnFilters<int> get id => $composableBuilder(
     column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get serverId => $composableBuilder(
-    column: $table.serverId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -3609,6 +3768,54 @@ class $$AppConfigsTableFilterComposer
     column: $table.usedPortsJson,
     builder: (column) => ColumnFilters(column),
   );
+
+  $$NasServersTableFilterComposer get serverId {
+    final $$NasServersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.serverId,
+      referencedTable: $db.nasServers,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$NasServersTableFilterComposer(
+            $db: $db,
+            $table: $db.nasServers,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<bool> appPortConfigsRefs(
+    Expression<bool> Function($$AppPortConfigsTableFilterComposer f) f,
+  ) {
+    final $$AppPortConfigsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.appPortConfigs,
+      getReferencedColumn: (t) => t.appConfigId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppPortConfigsTableFilterComposer(
+            $db: $db,
+            $table: $db.appPortConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$AppConfigsTableOrderingComposer
@@ -3622,11 +3829,6 @@ class $$AppConfigsTableOrderingComposer
   });
   ColumnOrderings<int> get id => $composableBuilder(
     column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<String> get serverId => $composableBuilder(
-    column: $table.serverId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -3769,6 +3971,29 @@ class $$AppConfigsTableOrderingComposer
     column: $table.usedPortsJson,
     builder: (column) => ColumnOrderings(column),
   );
+
+  $$NasServersTableOrderingComposer get serverId {
+    final $$NasServersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.serverId,
+      referencedTable: $db.nasServers,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$NasServersTableOrderingComposer(
+            $db: $db,
+            $table: $db.nasServers,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
 }
 
 class $$AppConfigsTableAnnotationComposer
@@ -3782,9 +4007,6 @@ class $$AppConfigsTableAnnotationComposer
   });
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
-
-  GeneratedColumn<String> get serverId =>
-      $composableBuilder(column: $table.serverId, builder: (column) => column);
 
   GeneratedColumn<String> get appName =>
       $composableBuilder(column: $table.appName, builder: (column) => column);
@@ -3895,6 +4117,54 @@ class $$AppConfigsTableAnnotationComposer
     column: $table.usedPortsJson,
     builder: (column) => column,
   );
+
+  $$NasServersTableAnnotationComposer get serverId {
+    final $$NasServersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.serverId,
+      referencedTable: $db.nasServers,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$NasServersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.nasServers,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<T> appPortConfigsRefs<T extends Object>(
+    Expression<T> Function($$AppPortConfigsTableAnnotationComposer a) f,
+  ) {
+    final $$AppPortConfigsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.appPortConfigs,
+      getReferencedColumn: (t) => t.appConfigId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppPortConfigsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.appPortConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$AppConfigsTableTableManager
@@ -3908,12 +4178,9 @@ class $$AppConfigsTableTableManager
           $$AppConfigsTableAnnotationComposer,
           $$AppConfigsTableCreateCompanionBuilder,
           $$AppConfigsTableUpdateCompanionBuilder,
-          (
-            AppConfigData,
-            BaseReferences<_$AppDatabase, $AppConfigsTable, AppConfigData>,
-          ),
+          (AppConfigData, $$AppConfigsTableReferences),
           AppConfigData,
-          PrefetchHooks Function()
+          PrefetchHooks Function({bool serverId, bool appPortConfigsRefs})
         > {
   $$AppConfigsTableTableManager(_$AppDatabase db, $AppConfigsTable table)
     : super(
@@ -4055,9 +4322,80 @@ class $$AppConfigsTableTableManager
                 usedPortsJson: usedPortsJson,
               ),
           withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$AppConfigsTableReferences(db, table, e),
+                ),
+              )
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback:
+              ({serverId = false, appPortConfigsRefs = false}) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [
+                    if (appPortConfigsRefs) db.appPortConfigs,
+                  ],
+                  addJoins:
+                      <
+                        T extends TableManagerState<
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic
+                        >
+                      >(state) {
+                        if (serverId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.serverId,
+                                    referencedTable: $$AppConfigsTableReferences
+                                        ._serverIdTable(db),
+                                    referencedColumn:
+                                        $$AppConfigsTableReferences
+                                            ._serverIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+
+                        return state;
+                      },
+                  getPrefetchedDataCallback: (items) async {
+                    return [
+                      if (appPortConfigsRefs)
+                        await $_getPrefetchedData<
+                          AppConfigData,
+                          $AppConfigsTable,
+                          AppPortConfigData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$AppConfigsTableReferences
+                              ._appPortConfigsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$AppConfigsTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).appPortConfigsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.appConfigId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                    ];
+                  },
+                );
+              },
         ),
       );
 }
@@ -4072,12 +4410,9 @@ typedef $$AppConfigsTableProcessedTableManager =
       $$AppConfigsTableAnnotationComposer,
       $$AppConfigsTableCreateCompanionBuilder,
       $$AppConfigsTableUpdateCompanionBuilder,
-      (
-        AppConfigData,
-        BaseReferences<_$AppDatabase, $AppConfigsTable, AppConfigData>,
-      ),
+      (AppConfigData, $$AppConfigsTableReferences),
       AppConfigData,
-      PrefetchHooks Function()
+      PrefetchHooks Function({bool serverId, bool appPortConfigsRefs})
     >;
 typedef $$AppPortConfigsTableCreateCompanionBuilder =
     AppPortConfigsCompanion Function({
@@ -4108,6 +4443,33 @@ typedef $$AppPortConfigsTableUpdateCompanionBuilder =
       Value<DateTime> updatedAt,
     });
 
+final class $$AppPortConfigsTableReferences
+    extends
+        BaseReferences<_$AppDatabase, $AppPortConfigsTable, AppPortConfigData> {
+  $$AppPortConfigsTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $AppConfigsTable _appConfigIdTable(_$AppDatabase db) => db.appConfigs
+      .createAlias('app_port_configs__app_config_id__app_configs__id');
+
+  $$AppConfigsTableProcessedTableManager get appConfigId {
+    final $_column = $_itemColumn<int>('app_config_id')!;
+
+    final manager = $$AppConfigsTableTableManager(
+      $_db,
+      $_db.appConfigs,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_appConfigIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
 class $$AppPortConfigsTableFilterComposer
     extends Composer<_$AppDatabase, $AppPortConfigsTable> {
   $$AppPortConfigsTableFilterComposer({
@@ -4119,11 +4481,6 @@ class $$AppPortConfigsTableFilterComposer
   });
   ColumnFilters<int> get id => $composableBuilder(
     column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<int> get appConfigId => $composableBuilder(
-    column: $table.appConfigId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4171,6 +4528,29 @@ class $$AppPortConfigsTableFilterComposer
     column: $table.updatedAt,
     builder: (column) => ColumnFilters(column),
   );
+
+  $$AppConfigsTableFilterComposer get appConfigId {
+    final $$AppConfigsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.appConfigId,
+      referencedTable: $db.appConfigs,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppConfigsTableFilterComposer(
+            $db: $db,
+            $table: $db.appConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
 }
 
 class $$AppPortConfigsTableOrderingComposer
@@ -4184,11 +4564,6 @@ class $$AppPortConfigsTableOrderingComposer
   });
   ColumnOrderings<int> get id => $composableBuilder(
     column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<int> get appConfigId => $composableBuilder(
-    column: $table.appConfigId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -4236,6 +4611,29 @@ class $$AppPortConfigsTableOrderingComposer
     column: $table.updatedAt,
     builder: (column) => ColumnOrderings(column),
   );
+
+  $$AppConfigsTableOrderingComposer get appConfigId {
+    final $$AppConfigsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.appConfigId,
+      referencedTable: $db.appConfigs,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppConfigsTableOrderingComposer(
+            $db: $db,
+            $table: $db.appConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
 }
 
 class $$AppPortConfigsTableAnnotationComposer
@@ -4249,11 +4647,6 @@ class $$AppPortConfigsTableAnnotationComposer
   });
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
-
-  GeneratedColumn<int> get appConfigId => $composableBuilder(
-    column: $table.appConfigId,
-    builder: (column) => column,
-  );
 
   GeneratedColumn<int> get portNumber => $composableBuilder(
     column: $table.portNumber,
@@ -4285,6 +4678,29 @@ class $$AppPortConfigsTableAnnotationComposer
 
   GeneratedColumn<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  $$AppConfigsTableAnnotationComposer get appConfigId {
+    final $$AppConfigsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.appConfigId,
+      referencedTable: $db.appConfigs,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AppConfigsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.appConfigs,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
 }
 
 class $$AppPortConfigsTableTableManager
@@ -4298,16 +4714,9 @@ class $$AppPortConfigsTableTableManager
           $$AppPortConfigsTableAnnotationComposer,
           $$AppPortConfigsTableCreateCompanionBuilder,
           $$AppPortConfigsTableUpdateCompanionBuilder,
-          (
-            AppPortConfigData,
-            BaseReferences<
-              _$AppDatabase,
-              $AppPortConfigsTable,
-              AppPortConfigData
-            >,
-          ),
+          (AppPortConfigData, $$AppPortConfigsTableReferences),
           AppPortConfigData,
-          PrefetchHooks Function()
+          PrefetchHooks Function({bool appConfigId})
         > {
   $$AppPortConfigsTableTableManager(
     _$AppDatabase db,
@@ -4375,9 +4784,55 @@ class $$AppPortConfigsTableTableManager
                 updatedAt: updatedAt,
               ),
           withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$AppPortConfigsTableReferences(db, table, e),
+                ),
+              )
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback: ({appConfigId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (appConfigId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.appConfigId,
+                                referencedTable: $$AppPortConfigsTableReferences
+                                    ._appConfigIdTable(db),
+                                referencedColumn:
+                                    $$AppPortConfigsTableReferences
+                                        ._appConfigIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
         ),
       );
 }
@@ -4392,12 +4847,9 @@ typedef $$AppPortConfigsTableProcessedTableManager =
       $$AppPortConfigsTableAnnotationComposer,
       $$AppPortConfigsTableCreateCompanionBuilder,
       $$AppPortConfigsTableUpdateCompanionBuilder,
-      (
-        AppPortConfigData,
-        BaseReferences<_$AppDatabase, $AppPortConfigsTable, AppPortConfigData>,
-      ),
+      (AppPortConfigData, $$AppPortConfigsTableReferences),
       AppPortConfigData,
-      PrefetchHooks Function()
+      PrefetchHooks Function({bool appConfigId})
     >;
 
 class $AppDatabaseManager {

--- a/lib/services/database.g.dart
+++ b/lib/services/database.g.dart
@@ -760,9 +760,6 @@ class $AppConfigsTable extends AppConfigs
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES nas_servers (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _appNameMeta = const VerificationMeta(
     'appName',
@@ -2404,9 +2401,6 @@ class $AppPortConfigsTable extends AppPortConfigs
     false,
     type: DriftSqlType.int,
     requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES app_configs (id) ON DELETE CASCADE',
-    ),
   );
   static const VerificationMeta _portNumberMeta = const VerificationMeta(
     'portNumber',
@@ -3049,23 +3043,6 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     appConfigs,
     appPortConfigs,
   ];
-  @override
-  StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'nas_servers',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('app_configs', kind: UpdateKind.delete)],
-    ),
-    WritePropagation(
-      on: TableUpdateQuery.onTableName(
-        'app_configs',
-        limitUpdateKind: UpdateKind.delete,
-      ),
-      result: [TableUpdate('app_port_configs', kind: UpdateKind.delete)],
-    ),
-  ]);
 }
 
 typedef $$NasServersTableCreateCompanionBuilder =
@@ -3100,29 +3077,6 @@ typedef $$NasServersTableUpdateCompanionBuilder =
       Value<bool> isDefault,
       Value<int> rowid,
     });
-
-final class $$NasServersTableReferences
-    extends BaseReferences<_$AppDatabase, $NasServersTable, NasServerData> {
-  $$NasServersTableReferences(super.$_db, super.$_table, super.$_typedResult);
-
-  static MultiTypedResultKey<$AppConfigsTable, List<AppConfigData>>
-  _appConfigsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-    db.appConfigs,
-    aliasName: $_aliasNameGenerator(db.nasServers.id, db.appConfigs.serverId),
-  );
-
-  $$AppConfigsTableProcessedTableManager get appConfigsRefs {
-    final manager = $$AppConfigsTableTableManager(
-      $_db,
-      $_db.appConfigs,
-    ).filter((f) => f.serverId.id.sqlEquals($_itemColumn<String>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(_appConfigsRefsTable($_db));
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-}
 
 class $$NasServersTableFilterComposer
     extends Composer<_$AppDatabase, $NasServersTable> {
@@ -3192,31 +3146,6 @@ class $$NasServersTableFilterComposer
     column: $table.isDefault,
     builder: (column) => ColumnFilters(column),
   );
-
-  Expression<bool> appConfigsRefs(
-    Expression<bool> Function($$AppConfigsTableFilterComposer f) f,
-  ) {
-    final $$AppConfigsTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.appConfigs,
-      getReferencedColumn: (t) => t.serverId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppConfigsTableFilterComposer(
-            $db: $db,
-            $table: $db.appConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
 }
 
 class $$NasServersTableOrderingComposer
@@ -3339,31 +3268,6 @@ class $$NasServersTableAnnotationComposer
 
   GeneratedColumn<bool> get isDefault =>
       $composableBuilder(column: $table.isDefault, builder: (column) => column);
-
-  Expression<T> appConfigsRefs<T extends Object>(
-    Expression<T> Function($$AppConfigsTableAnnotationComposer a) f,
-  ) {
-    final $$AppConfigsTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.appConfigs,
-      getReferencedColumn: (t) => t.serverId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppConfigsTableAnnotationComposer(
-            $db: $db,
-            $table: $db.appConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
 }
 
 class $$NasServersTableTableManager
@@ -3377,9 +3281,12 @@ class $$NasServersTableTableManager
           $$NasServersTableAnnotationComposer,
           $$NasServersTableCreateCompanionBuilder,
           $$NasServersTableUpdateCompanionBuilder,
-          (NasServerData, $$NasServersTableReferences),
+          (
+            NasServerData,
+            BaseReferences<_$AppDatabase, $NasServersTable, NasServerData>,
+          ),
           NasServerData,
-          PrefetchHooks Function({bool appConfigsRefs})
+          PrefetchHooks Function()
         > {
   $$NasServersTableTableManager(_$AppDatabase db, $NasServersTable table)
     : super(
@@ -3453,43 +3360,9 @@ class $$NasServersTableTableManager
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$NasServersTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({appConfigsRefs = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [if (appConfigsRefs) db.appConfigs],
-              addJoins: null,
-              getPrefetchedDataCallback: (items) async {
-                return [
-                  if (appConfigsRefs)
-                    await $_getPrefetchedData<
-                      NasServerData,
-                      $NasServersTable,
-                      AppConfigData
-                    >(
-                      currentTable: table,
-                      referencedTable: $$NasServersTableReferences
-                          ._appConfigsRefsTable(db),
-                      managerFromTypedResult: (p0) =>
-                          $$NasServersTableReferences(
-                            db,
-                            table,
-                            p0,
-                          ).appConfigsRefs,
-                      referencedItemsForCurrentItem: (item, referencedItems) =>
-                          referencedItems.where((e) => e.serverId == item.id),
-                      typedResults: items,
-                    ),
-                ];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -3504,9 +3377,12 @@ typedef $$NasServersTableProcessedTableManager =
       $$NasServersTableAnnotationComposer,
       $$NasServersTableCreateCompanionBuilder,
       $$NasServersTableUpdateCompanionBuilder,
-      (NasServerData, $$NasServersTableReferences),
+      (
+        NasServerData,
+        BaseReferences<_$AppDatabase, $NasServersTable, NasServerData>,
+      ),
       NasServerData,
-      PrefetchHooks Function({bool appConfigsRefs})
+      PrefetchHooks Function()
     >;
 typedef $$AppConfigsTableCreateCompanionBuilder =
     AppConfigsCompanion Function({
@@ -3575,51 +3451,6 @@ typedef $$AppConfigsTableUpdateCompanionBuilder =
       Value<String?> usedPortsJson,
     });
 
-final class $$AppConfigsTableReferences
-    extends BaseReferences<_$AppDatabase, $AppConfigsTable, AppConfigData> {
-  $$AppConfigsTableReferences(super.$_db, super.$_table, super.$_typedResult);
-
-  static $NasServersTable _serverIdTable(_$AppDatabase db) =>
-      db.nasServers.createAlias(
-        $_aliasNameGenerator(db.appConfigs.serverId, db.nasServers.id),
-      );
-
-  $$NasServersTableProcessedTableManager get serverId {
-    final $_column = $_itemColumn<String>('server_id')!;
-
-    final manager = $$NasServersTableTableManager(
-      $_db,
-      $_db.nasServers,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_serverIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-
-  static MultiTypedResultKey<$AppPortConfigsTable, List<AppPortConfigData>>
-  _appPortConfigsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-    db.appPortConfigs,
-    aliasName: $_aliasNameGenerator(
-      db.appConfigs.id,
-      db.appPortConfigs.appConfigId,
-    ),
-  );
-
-  $$AppPortConfigsTableProcessedTableManager get appPortConfigsRefs {
-    final manager = $$AppPortConfigsTableTableManager(
-      $_db,
-      $_db.appPortConfigs,
-    ).filter((f) => f.appConfigId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(_appPortConfigsRefsTable($_db));
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
-    );
-  }
-}
-
 class $$AppConfigsTableFilterComposer
     extends Composer<_$AppDatabase, $AppConfigsTable> {
   $$AppConfigsTableFilterComposer({
@@ -3631,6 +3462,11 @@ class $$AppConfigsTableFilterComposer
   });
   ColumnFilters<int> get id => $composableBuilder(
     column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get serverId => $composableBuilder(
+    column: $table.serverId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -3773,54 +3609,6 @@ class $$AppConfigsTableFilterComposer
     column: $table.usedPortsJson,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$NasServersTableFilterComposer get serverId {
-    final $$NasServersTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.serverId,
-      referencedTable: $db.nasServers,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$NasServersTableFilterComposer(
-            $db: $db,
-            $table: $db.nasServers,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
-
-  Expression<bool> appPortConfigsRefs(
-    Expression<bool> Function($$AppPortConfigsTableFilterComposer f) f,
-  ) {
-    final $$AppPortConfigsTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.appPortConfigs,
-      getReferencedColumn: (t) => t.appConfigId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppPortConfigsTableFilterComposer(
-            $db: $db,
-            $table: $db.appPortConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
 }
 
 class $$AppConfigsTableOrderingComposer
@@ -3834,6 +3622,11 @@ class $$AppConfigsTableOrderingComposer
   });
   ColumnOrderings<int> get id => $composableBuilder(
     column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get serverId => $composableBuilder(
+    column: $table.serverId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -3976,29 +3769,6 @@ class $$AppConfigsTableOrderingComposer
     column: $table.usedPortsJson,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$NasServersTableOrderingComposer get serverId {
-    final $$NasServersTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.serverId,
-      referencedTable: $db.nasServers,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$NasServersTableOrderingComposer(
-            $db: $db,
-            $table: $db.nasServers,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$AppConfigsTableAnnotationComposer
@@ -4012,6 +3782,9 @@ class $$AppConfigsTableAnnotationComposer
   });
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get serverId =>
+      $composableBuilder(column: $table.serverId, builder: (column) => column);
 
   GeneratedColumn<String> get appName =>
       $composableBuilder(column: $table.appName, builder: (column) => column);
@@ -4122,54 +3895,6 @@ class $$AppConfigsTableAnnotationComposer
     column: $table.usedPortsJson,
     builder: (column) => column,
   );
-
-  $$NasServersTableAnnotationComposer get serverId {
-    final $$NasServersTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.serverId,
-      referencedTable: $db.nasServers,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$NasServersTableAnnotationComposer(
-            $db: $db,
-            $table: $db.nasServers,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
-
-  Expression<T> appPortConfigsRefs<T extends Object>(
-    Expression<T> Function($$AppPortConfigsTableAnnotationComposer a) f,
-  ) {
-    final $$AppPortConfigsTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.appPortConfigs,
-      getReferencedColumn: (t) => t.appConfigId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppPortConfigsTableAnnotationComposer(
-            $db: $db,
-            $table: $db.appPortConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
 }
 
 class $$AppConfigsTableTableManager
@@ -4183,9 +3908,12 @@ class $$AppConfigsTableTableManager
           $$AppConfigsTableAnnotationComposer,
           $$AppConfigsTableCreateCompanionBuilder,
           $$AppConfigsTableUpdateCompanionBuilder,
-          (AppConfigData, $$AppConfigsTableReferences),
+          (
+            AppConfigData,
+            BaseReferences<_$AppDatabase, $AppConfigsTable, AppConfigData>,
+          ),
           AppConfigData,
-          PrefetchHooks Function({bool serverId, bool appPortConfigsRefs})
+          PrefetchHooks Function()
         > {
   $$AppConfigsTableTableManager(_$AppDatabase db, $AppConfigsTable table)
     : super(
@@ -4327,80 +4055,9 @@ class $$AppConfigsTableTableManager
                 usedPortsJson: usedPortsJson,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$AppConfigsTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback:
-              ({serverId = false, appPortConfigsRefs = false}) {
-                return PrefetchHooks(
-                  db: db,
-                  explicitlyWatchedTables: [
-                    if (appPortConfigsRefs) db.appPortConfigs,
-                  ],
-                  addJoins:
-                      <
-                        T extends TableManagerState<
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic,
-                          dynamic
-                        >
-                      >(state) {
-                        if (serverId) {
-                          state =
-                              state.withJoin(
-                                    currentTable: table,
-                                    currentColumn: table.serverId,
-                                    referencedTable: $$AppConfigsTableReferences
-                                        ._serverIdTable(db),
-                                    referencedColumn:
-                                        $$AppConfigsTableReferences
-                                            ._serverIdTable(db)
-                                            .id,
-                                  )
-                                  as T;
-                        }
-
-                        return state;
-                      },
-                  getPrefetchedDataCallback: (items) async {
-                    return [
-                      if (appPortConfigsRefs)
-                        await $_getPrefetchedData<
-                          AppConfigData,
-                          $AppConfigsTable,
-                          AppPortConfigData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$AppConfigsTableReferences
-                              ._appPortConfigsRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$AppConfigsTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).appPortConfigsRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.appConfigId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
-                    ];
-                  },
-                );
-              },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -4415,9 +4072,12 @@ typedef $$AppConfigsTableProcessedTableManager =
       $$AppConfigsTableAnnotationComposer,
       $$AppConfigsTableCreateCompanionBuilder,
       $$AppConfigsTableUpdateCompanionBuilder,
-      (AppConfigData, $$AppConfigsTableReferences),
+      (
+        AppConfigData,
+        BaseReferences<_$AppDatabase, $AppConfigsTable, AppConfigData>,
+      ),
       AppConfigData,
-      PrefetchHooks Function({bool serverId, bool appPortConfigsRefs})
+      PrefetchHooks Function()
     >;
 typedef $$AppPortConfigsTableCreateCompanionBuilder =
     AppPortConfigsCompanion Function({
@@ -4448,35 +4108,6 @@ typedef $$AppPortConfigsTableUpdateCompanionBuilder =
       Value<DateTime> updatedAt,
     });
 
-final class $$AppPortConfigsTableReferences
-    extends
-        BaseReferences<_$AppDatabase, $AppPortConfigsTable, AppPortConfigData> {
-  $$AppPortConfigsTableReferences(
-    super.$_db,
-    super.$_table,
-    super.$_typedResult,
-  );
-
-  static $AppConfigsTable _appConfigIdTable(_$AppDatabase db) =>
-      db.appConfigs.createAlias(
-        $_aliasNameGenerator(db.appPortConfigs.appConfigId, db.appConfigs.id),
-      );
-
-  $$AppConfigsTableProcessedTableManager get appConfigId {
-    final $_column = $_itemColumn<int>('app_config_id')!;
-
-    final manager = $$AppConfigsTableTableManager(
-      $_db,
-      $_db.appConfigs,
-    ).filter((f) => f.id.sqlEquals($_column));
-    final item = $_typedResult.readTableOrNull(_appConfigIdTable($_db));
-    if (item == null) return manager;
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-}
-
 class $$AppPortConfigsTableFilterComposer
     extends Composer<_$AppDatabase, $AppPortConfigsTable> {
   $$AppPortConfigsTableFilterComposer({
@@ -4488,6 +4119,11 @@ class $$AppPortConfigsTableFilterComposer
   });
   ColumnFilters<int> get id => $composableBuilder(
     column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get appConfigId => $composableBuilder(
+    column: $table.appConfigId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4535,29 +4171,6 @@ class $$AppPortConfigsTableFilterComposer
     column: $table.updatedAt,
     builder: (column) => ColumnFilters(column),
   );
-
-  $$AppConfigsTableFilterComposer get appConfigId {
-    final $$AppConfigsTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.appConfigId,
-      referencedTable: $db.appConfigs,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppConfigsTableFilterComposer(
-            $db: $db,
-            $table: $db.appConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$AppPortConfigsTableOrderingComposer
@@ -4571,6 +4184,11 @@ class $$AppPortConfigsTableOrderingComposer
   });
   ColumnOrderings<int> get id => $composableBuilder(
     column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get appConfigId => $composableBuilder(
+    column: $table.appConfigId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -4618,29 +4236,6 @@ class $$AppPortConfigsTableOrderingComposer
     column: $table.updatedAt,
     builder: (column) => ColumnOrderings(column),
   );
-
-  $$AppConfigsTableOrderingComposer get appConfigId {
-    final $$AppConfigsTableOrderingComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.appConfigId,
-      referencedTable: $db.appConfigs,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppConfigsTableOrderingComposer(
-            $db: $db,
-            $table: $db.appConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$AppPortConfigsTableAnnotationComposer
@@ -4654,6 +4249,11 @@ class $$AppPortConfigsTableAnnotationComposer
   });
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get appConfigId => $composableBuilder(
+    column: $table.appConfigId,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<int> get portNumber => $composableBuilder(
     column: $table.portNumber,
@@ -4685,29 +4285,6 @@ class $$AppPortConfigsTableAnnotationComposer
 
   GeneratedColumn<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
-
-  $$AppConfigsTableAnnotationComposer get appConfigId {
-    final $$AppConfigsTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.appConfigId,
-      referencedTable: $db.appConfigs,
-      getReferencedColumn: (t) => t.id,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$AppConfigsTableAnnotationComposer(
-            $db: $db,
-            $table: $db.appConfigs,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return composer;
-  }
 }
 
 class $$AppPortConfigsTableTableManager
@@ -4721,9 +4298,16 @@ class $$AppPortConfigsTableTableManager
           $$AppPortConfigsTableAnnotationComposer,
           $$AppPortConfigsTableCreateCompanionBuilder,
           $$AppPortConfigsTableUpdateCompanionBuilder,
-          (AppPortConfigData, $$AppPortConfigsTableReferences),
+          (
+            AppPortConfigData,
+            BaseReferences<
+              _$AppDatabase,
+              $AppPortConfigsTable,
+              AppPortConfigData
+            >,
+          ),
           AppPortConfigData,
-          PrefetchHooks Function({bool appConfigId})
+          PrefetchHooks Function()
         > {
   $$AppPortConfigsTableTableManager(
     _$AppDatabase db,
@@ -4791,55 +4375,9 @@ class $$AppPortConfigsTableTableManager
                 updatedAt: updatedAt,
               ),
           withReferenceMapper: (p0) => p0
-              .map(
-                (e) => (
-                  e.readTable(table),
-                  $$AppPortConfigsTableReferences(db, table, e),
-                ),
-              )
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({appConfigId = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [],
-              addJoins:
-                  <
-                    T extends TableManagerState<
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic,
-                      dynamic
-                    >
-                  >(state) {
-                    if (appConfigId) {
-                      state =
-                          state.withJoin(
-                                currentTable: table,
-                                currentColumn: table.appConfigId,
-                                referencedTable: $$AppPortConfigsTableReferences
-                                    ._appConfigIdTable(db),
-                                referencedColumn:
-                                    $$AppPortConfigsTableReferences
-                                        ._appConfigIdTable(db)
-                                        .id,
-                              )
-                              as T;
-                    }
-
-                    return state;
-                  },
-              getPrefetchedDataCallback: (items) async {
-                return [];
-              },
-            );
-          },
+          prefetchHooksCallback: null,
         ),
       );
 }
@@ -4854,9 +4392,12 @@ typedef $$AppPortConfigsTableProcessedTableManager =
       $$AppPortConfigsTableAnnotationComposer,
       $$AppPortConfigsTableCreateCompanionBuilder,
       $$AppPortConfigsTableUpdateCompanionBuilder,
-      (AppPortConfigData, $$AppPortConfigsTableReferences),
+      (
+        AppPortConfigData,
+        BaseReferences<_$AppDatabase, $AppPortConfigsTable, AppPortConfigData>,
+      ),
       AppPortConfigData,
-      PrefetchHooks Function({bool appConfigId})
+      PrefetchHooks Function()
     >;
 
 class $AppDatabaseManager {

--- a/lib/widgets/action_button_widget.dart
+++ b/lib/widgets/action_button_widget.dart
@@ -31,7 +31,7 @@ class ActionButtonWidget extends StatelessWidget {
               width: 48,
               height: 48,
               decoration: BoxDecoration(
-                color: CupertinoColors.activeBlue.withOpacity(0.1),
+                color: CupertinoColors.activeBlue.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Icon(icon, color: CupertinoColors.activeBlue, size: 24),

--- a/lib/widgets/app_card_widget.dart
+++ b/lib/widgets/app_card_widget.dart
@@ -93,8 +93,8 @@ class AppCardWidget extends StatelessWidget {
                   ),
                   decoration: BoxDecoration(
                     color: app.installed
-                        ? CupertinoColors.systemGreen.withOpacity(0.1)
-                        : CupertinoColors.systemBlue.withOpacity(0.1),
+                        ? CupertinoColors.systemGreen.withValues(alpha: 0.1)
+                        : CupertinoColors.systemBlue.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -151,7 +151,7 @@ class AppCardWidget extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemGrey6.withOpacity(0.5),
+                  color: CupertinoColors.systemGrey6.withValues(alpha: 0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Column(
@@ -250,7 +250,7 @@ class AppCardWidget extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemYellow.withOpacity(0.1),
+                  color: CupertinoColors.systemYellow.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(
@@ -297,7 +297,7 @@ class AppCardWidget extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemBlue.withOpacity(0.1),
+                  color: CupertinoColors.systemBlue.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Column(
@@ -327,7 +327,9 @@ class AppCardWidget extends StatelessWidget {
                       Container(
                         padding: const EdgeInsets.all(8),
                         decoration: BoxDecoration(
-                          color: CupertinoColors.systemGreen.withOpacity(0.1),
+                          color: CupertinoColors.systemGreen.withValues(
+                            alpha: 0.1,
+                          ),
                           borderRadius: BorderRadius.circular(6),
                         ),
                         child: Row(
@@ -428,7 +430,7 @@ class AppCardWidget extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: CupertinoColors.systemRed.withOpacity(0.1),
+                  color: CupertinoColors.systemRed.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(

--- a/lib/widgets/app_icon.dart
+++ b/lib/widgets/app_icon.dart
@@ -21,9 +21,9 @@ class AppIcon extends StatelessWidget {
         fallbackBackgroundColor ??
         (app.installed
             ? (app.healthy
-                  ? CupertinoColors.systemGreen.withOpacity(0.1)
-                  : CupertinoColors.systemRed.withOpacity(0.1))
-            : CupertinoColors.systemBlue.withOpacity(0.1));
+                  ? CupertinoColors.systemGreen.withValues(alpha: 0.1)
+                  : CupertinoColors.systemRed.withValues(alpha: 0.1))
+            : CupertinoColors.systemBlue.withValues(alpha: 0.1));
 
     final iconColor =
         fallbackIconColor ??

--- a/lib/widgets/connection_error_widget.dart
+++ b/lib/widgets/connection_error_widget.dart
@@ -143,9 +143,11 @@ class CompactConnectionErrorWidget extends StatelessWidget {
       padding: const EdgeInsets.all(12),
       margin: const EdgeInsets.all(8),
       decoration: BoxDecoration(
-        color: CupertinoColors.systemRed.withOpacity(0.1),
+        color: CupertinoColors.systemRed.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: CupertinoColors.systemRed.withOpacity(0.3)),
+        border: Border.all(
+          color: CupertinoColors.systemRed.withValues(alpha: 0.3),
+        ),
       ),
       child: Row(
         children: [

--- a/lib/widgets/pool_card_widget.dart
+++ b/lib/widgets/pool_card_widget.dart
@@ -43,8 +43,8 @@ class PoolCardWidget extends StatelessWidget {
                   height: 44,
                   decoration: BoxDecoration(
                     color: healthy
-                        ? CupertinoColors.systemGreen.withOpacity(0.1)
-                        : CupertinoColors.systemRed.withOpacity(0.1),
+                        ? CupertinoColors.systemGreen.withValues(alpha: 0.1)
+                        : CupertinoColors.systemRed.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: Icon(
@@ -88,8 +88,8 @@ class PoolCardWidget extends StatelessWidget {
                       ),
                       decoration: BoxDecoration(
                         color: healthy
-                            ? CupertinoColors.systemGreen.withOpacity(0.1)
-                            : CupertinoColors.systemRed.withOpacity(0.1),
+                            ? CupertinoColors.systemGreen.withValues(alpha: 0.1)
+                            : CupertinoColors.systemRed.withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(6),
                       ),
                       child: Text(

--- a/lib/widgets/server_list_tile.dart
+++ b/lib/widgets/server_list_tile.dart
@@ -67,8 +67,8 @@ class ServerListTile extends StatelessWidget {
                 height: 40,
                 decoration: BoxDecoration(
                   color: server.isActive
-                      ? CupertinoColors.activeGreen.withOpacity(0.1)
-                      : CupertinoColors.systemGrey.withOpacity(0.1),
+                      ? CupertinoColors.activeGreen.withValues(alpha: 0.1)
+                      : CupertinoColors.systemGrey.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Icon(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,6 @@ import connectivity_plus
 import flutter_secure_storage_macos
 import local_auth_darwin
 import network_info_plus
-import path_provider_foundation
 import sqlite3_flutter_libs
 import tray_manager
 import truenas_native_plugins
@@ -20,7 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   TruenasNativePlugins.register(with: registry.registrar(forPlugin: "TruenasNativePlugins"))

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,6 @@ import connectivity_plus
 import flutter_secure_storage_macos
 import local_auth_darwin
 import network_info_plus
-import sqlite3_flutter_libs
 import tray_manager
 import truenas_native_plugins
 import url_launcher_macos
@@ -19,7 +18,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   TruenasNativePlugins.register(with: registry.registrar(forPlugin: "TruenasNativePlugins"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -9,9 +9,6 @@ PODS:
     - FlutterMacOS
   - network_info_plus (0.0.1):
     - FlutterMacOS
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - sqlite3 (3.52.0):
     - sqlite3/common (= 3.52.0)
   - sqlite3/common (3.52.0)
@@ -50,7 +47,6 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
   - network_info_plus (from `Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
   - truenas_native_plugins (from `Flutter/ephemeral/.symlinks/plugins/truenas_native_plugins/macos`)
@@ -71,8 +67,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
   network_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos
-  path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   sqlite3_flutter_libs:
     :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
   tray_manager:
@@ -85,15 +79,14 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   connectivity_plus: 0a976dfd033b59192912fa3c6c7b54aab5093802
   flutter_secure_storage_macos: c2754d3483d20bb207bb9e5a14f1b8e771abcdb9
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  local_auth_darwin: fa4b06454df7df8e97c18d7ee55151c57e7af0de
+  FlutterMacOS: c232990155153907050900a2e175c7773903ba4e
+  local_auth_darwin: 63c73d6d28cc3e239be2b6aa460ea6e317cd5100
   network_info_plus: 2cb02d8435635eae13b3b79279681985121cf30c
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
   sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
   tray_manager: c2a678ee19e2a094f0c2d03660ee2c3e81cea8ab
   truenas_native_plugins: 2b234f3726a22840001a3534747f40f5509b709e
-  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
+  url_launcher_macos: 175a54c831f4375a6cf895875f716ee5af3888ce
 
 PODFILE CHECKSUM: 7eb978b976557c8c1cd717d8185ec483fd090a82
 

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -9,31 +9,6 @@ PODS:
     - FlutterMacOS
   - network_info_plus (0.0.1):
     - FlutterMacOS
-  - sqlite3 (3.52.0):
-    - sqlite3/common (= 3.52.0)
-  - sqlite3/common (3.52.0)
-  - sqlite3/dbstatvtab (3.52.0):
-    - sqlite3/common
-  - sqlite3/fts5 (3.52.0):
-    - sqlite3/common
-  - sqlite3/math (3.52.0):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.52.0):
-    - sqlite3/common
-  - sqlite3/rtree (3.52.0):
-    - sqlite3/common
-  - sqlite3/session (3.52.0):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.52.0)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
   - tray_manager (0.0.1):
     - FlutterMacOS
   - truenas_native_plugins (0.1.0):
@@ -47,14 +22,9 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
   - network_info_plus (from `Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos`)
-  - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
   - truenas_native_plugins (from `Flutter/ephemeral/.symlinks/plugins/truenas_native_plugins/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-
-SPEC REPOS:
-  trunk:
-    - sqlite3
 
 EXTERNAL SOURCES:
   connectivity_plus:
@@ -67,8 +37,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
   network_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos
-  sqlite3_flutter_libs:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
   tray_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/tray_manager/macos
   truenas_native_plugins:
@@ -82,8 +50,6 @@ SPEC CHECKSUMS:
   FlutterMacOS: c232990155153907050900a2e175c7773903ba4e
   local_auth_darwin: 63c73d6d28cc3e239be2b6aa460ea6e317cd5100
   network_info_plus: 2cb02d8435635eae13b3b79279681985121cf30c
-  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
-  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
   tray_manager: c2a678ee19e2a094f0c2d03660ee2c3e81cea8ab
   truenas_native_plugins: 2b234f3726a22840001a3534747f40f5509b709e
   url_launcher_macos: 175a54c831f4375a6cf895875f716ee5af3888ce

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "96.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "10.2.0"
   args:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,50 +45,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.2"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.1"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -141,18 +125,18 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: e51d50bca3217c9a9fa2b41a30e4a38971133f5f9ec7a3d57bae095007f1d28e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
-  code_builder:
+    version: "1.1.3"
+  code_assets:
     dependency: transitive
     description:
-      name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
+      name: code_assets
+      sha256: cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.1"
+    version: "2.0.0"
   collection:
     dependency: transitive
     description:
@@ -205,10 +189,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   cupertino_sidebar:
     dependency: "direct main"
     description:
@@ -221,18 +205,18 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_pre_commit
-      sha256: ea6b1e77383462957213425a5b85c4641b50cbe2bc0a6db574642c30713c9358
+      sha256: cd8962e2e8e6cc3800c960ea85449e5407792ac52c053cbd9966af7a077c9f32
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.7"
+    version: "6.1.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
@@ -261,26 +245,26 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "83290a32ae006a7535c5ecf300722cb77177250d9df4ee2becc5fa8a36095114"
+      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.29.0"
+    version: "2.31.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "6019f827544e77524ffd5134ae0cb75dfd92ef5ef3e269872af92840c929cd43"
+      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
       url: "https://pub.dev"
     source: hosted
-    version: "2.29.0"
+    version: "2.31.0"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: b7534bf320aac5213259aac120670ba67b63a1fd010505babc436ff86083818f
+      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.8"
   equatable:
     dependency: "direct main"
     description:
@@ -325,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: d3f82f4a38e33ba23d05a08ff304d7d8b22d2a59a5503f20bd802966e915db89
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -346,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: c2fe1001710127dfa7da89977a08d591398370d099aacdaa6d44da7eb14b8476
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.31"
+    version: "2.0.35"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -424,14 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  frontend_server_client:
+  get_it:
     dependency: transitive
     description:
-      name: frontend_server_client
-      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      name: get_it
+      sha256: "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "9.2.1"
   glob:
     dependency: transitive
     description:
@@ -456,6 +440,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -472,14 +464,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  injectable:
+    dependency: transitive
+    description:
+      name: injectable
+      sha256: "1da6399509e44ddb0d8a4a35291d7122c4efb5c625a9d733bf5e48d4a72e379e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   intl:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -488,6 +488,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
@@ -500,10 +524,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_rpc_2:
     dependency: "direct main"
     description:
@@ -516,26 +540,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -556,18 +580,18 @@ packages:
     dependency: transitive
     description:
       name: local_auth_android
-      sha256: "48924f4a8b3cc45994ad5993e2e232d3b00788a305c1bf1c7db32cef281ce9a3"
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.52"
+    version: "1.0.56"
   local_auth_darwin:
     dependency: transitive
     description:
       name: local_auth_darwin
-      sha256: "0e9706a8543a4a2eee60346294d6a633dd7c3ee60fae6b752570457c4ff32055"
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -596,18 +620,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   menu_base:
     dependency: transitive
     description:
@@ -620,10 +644,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -664,6 +688,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: ad56fd53a78ff6b1472fa59ff2a4e8b8ccabafc586fc263a1dfad0b99b5553e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.6.0"
   package_config:
     dependency: transitive
     description:
@@ -684,42 +716,42 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "3b4c1fc3aa55ddc9cd4aa6759984330d5c8e66aa7702a6223c61540dc6380c37"
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.19"
+    version: "2.3.1"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -840,14 +872,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  riverpod:
+  record_use:
     dependency: transitive
     description:
-      name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      name: record_use
+      sha256: "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "1.1.1"
   shelf:
     dependency: transitive
     description:
@@ -881,18 +913,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "800f12fb87434defa13432ab37e33051b43b290a174e15259563b043cda40c46"
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.2.4"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   sqlite3:
     dependency: transitive
     description:
@@ -913,26 +945,18 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "162435ede92bcc793ea939fdc0452eef0a73d11f8ed053b58a89792fba749da5"
+      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
       url: "https://pub.dev"
     source: hosted
-    version: "0.42.1"
+    version: "0.43.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "277654b3034d17ac6f9f1cb5595db011b1d5d41e8806866db28e0abaa101c490"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
-  state_notifier:
-    dependency: transitive
-    description:
-      name: state_notifier
-      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "1.12.2"
   stream_channel:
     dependency: "direct main"
     description:
@@ -969,18 +993,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
+    version: "0.7.12"
   tray_manager:
     dependency: "direct main"
     description:
@@ -1016,34 +1032,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "81777b08c498a292d93ff2feead633174c386291e35612f8da438d6e92c4447e"
+      sha256: "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.20"
+    version: "6.3.33"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      sha256: "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "6.4.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      sha256: "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      sha256: "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.6"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1056,18 +1072,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      sha256: "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   uuid:
     dependency: "direct main"
     description:
@@ -1080,18 +1096,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.3.0"
   watcher:
     dependency: transitive
     description:
@@ -1144,10 +1160,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -1157,5 +1173,5 @@ packages:
     source: hosted
     version: "3.1.4"
 sdks:
-  dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.32.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "96.0.0"
+    version: "103.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "13.3.0"
   args:
     dependency: transitive
     description:
@@ -205,18 +205,18 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_pre_commit
-      sha256: cd8962e2e8e6cc3800c960ea85449e5407792ac52c053cbd9966af7a077c9f32
+      sha256: "452aa230a1cc6d37770c3d8a359e002be10a9c535546e8a1323c5b4445817930"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      sha256: "82ade9fc4273f29ed673e33166944465225b4f7fc5d4aaef48605cc751c18fc1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.13"
   dbus:
     dependency: transitive
     description:
@@ -245,26 +245,26 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "3a3f1f6f905037d7426e4c445854139fd6a3d592135f7c96d7931682b73d16f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.3"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "735aad3c34215805c66bd518c8812fa4f83b5534b2c13c4092c970c04a7e9983"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.5"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.3.1"
   equatable:
     dependency: "direct main"
     description:
@@ -656,6 +656,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "9d233b6f2d9c52e1a2b5fbe70451d2c10ac674d3bb419d0ec8de14989d437c26"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.4"
   nested:
     dependency: transitive
     description:
@@ -840,6 +848,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.3"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "4242ba3508d37e01808bdf71ad1d5bb93a8d671bf2e7450e6b1b353fb0808891"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.6"
   provider:
     dependency: "direct main"
     description:
@@ -925,30 +941,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: "4c7fe79840389aaeaf05fd093f795b631b5a98e2bd28d54e555c100f4a9c7a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.2"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "772bb2f6f5bce0631a60f26b57d6e8882e1105c22345b05c163ee6ee5d7ba32d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.45.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1173,5 +1197,5 @@ packages:
     source: hosted
     version: "3.1.4"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
+  dart: ">=3.13.0 <4.0.0"
   flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,8 +43,8 @@ dependencies:
   json_rpc_2: ^4.0.0
 
   # Local storage
-  drift: ^2.27.0
-  drift_flutter: ^0.2.4
+  drift: ^2.34.3
+  drift_flutter: ^0.3.1
   path_provider: ^2.1.5
   path: ^1.9.1
 
@@ -96,9 +96,9 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
-  drift_dev: ^2.27.0
+  drift_dev: ^2.34.5
   build_runner: ^2.5.4
-  dart_pre_commit: ^6.0.0
+  dart_pre_commit: ^6.1.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.1+1
 
 environment:
-  sdk: ^3.8.1
+  sdk: ^3.9.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -57,7 +57,7 @@ dependencies:
 
   # UI enhancements
   flutter_slidable: ^4.0.0
-  fl_chart: ^1.0.0
+  fl_chart: ^1.1.1
   stream_channel: ^2.1.4
 
   # WebSocket support
@@ -98,7 +98,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   drift_dev: ^2.27.0
   build_runner: ^2.5.4
-  dart_pre_commit: ^5.4.7
+  dart_pre_commit: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/debug/server_refresh_test.dart
+++ b/test/debug/server_refresh_test.dart
@@ -130,64 +130,60 @@ void main() {
       expect(finalServer?.port, null);
     });
 
-    test(
-      'should notify listeners when server is updated',
-      () async {
-        // This test was hanging when running with other tests due to authentication
-        // triggering during updateServer. Simplified to test the core functionality.
+    test('should notify listeners when server is updated', () async {
+      // This test was hanging when running with other tests due to authentication
+      // triggering during updateServer. Simplified to test the core functionality.
 
-        int notificationCount = 0;
+      int notificationCount = 0;
 
-        // Add a listener that counts notifications
-        void countingListener() {
-          notificationCount++;
-        }
+      // Add a listener that counts notifications
+      void countingListener() {
+        notificationCount++;
+      }
 
-        serverProvider.addListener(countingListener);
+      serverProvider.addListener(countingListener);
 
-        try {
-          // Create a test server directly in database
-          final testServer = models.NasServer.create(
-            name: 'Listener Test Server',
-            host: 'listener.test.com',
-            port: 443,
-            username: 'admin',
-            password: 'password',
-            useHttps: true,
-          );
+      try {
+        // Create a test server directly in database
+        final testServer = models.NasServer.create(
+          name: 'Listener Test Server',
+          host: 'listener.test.com',
+          port: 443,
+          username: 'admin',
+          password: 'password',
+          useHttps: true,
+        );
 
-          await database.insertServer(testServer);
+        await database.insertServer(testServer);
 
-          // Select the server first to avoid authentication during update
-          serverProvider.selectServer(testServer);
+        // Select the server first to avoid authentication during update
+        serverProvider.selectServer(testServer);
 
-          // Reset counter after selection
-          notificationCount = 0;
+        // Reset counter after selection
+        notificationCount = 0;
 
-          // Update the server - this should trigger listener notification
-          final updatedServer = testServer.copyWith(
-            name: 'Updated Listener Server',
-          );
-          await serverProvider.updateServer(updatedServer);
+        // Update the server - this should trigger listener notification
+        final updatedServer = testServer.copyWith(
+          name: 'Updated Listener Server',
+        );
+        await serverProvider.updateServer(updatedServer);
 
-          // Verify listeners were notified at least once
-          expect(
-            notificationCount,
-            greaterThan(0),
-            reason: 'Listener should be notified when server is updated',
-          );
-        } finally {
-          // Always clean up listener
-          serverProvider.removeListener(countingListener);
+        // Verify listeners were notified at least once
+        expect(
+          notificationCount,
+          greaterThan(0),
+          reason: 'Listener should be notified when server is updated',
+        );
+      } finally {
+        // Always clean up listener
+        serverProvider.removeListener(countingListener);
 
-          // Clear selected server to prevent lingering API clients
-          serverProvider.clearSelectedServer();
+        // Clear selected server to prevent lingering API clients
+        serverProvider.clearSelectedServer();
 
-          // Ensure API clients are cleaned up
-          await TestProviders.cleanupTestEnvironment();
-        }
-      },
-      timeout: const Timeout(Duration(seconds: 5)),
-    );
+        // Ensure API clients are cleaned up
+        await TestProviders.cleanupTestEnvironment();
+      }
+    }, timeout: const Timeout(Duration(seconds: 5)));
   });
 }


### PR DESCRIPTION
The workflow pinned Flutter 3.32.6 (Dart 3.8.1), about a year behind stable and the reason two dependency updates could not land. This moves to the current stable, 3.47.2 / Dart 3.13.2.

## What this unblocks

- **`dart_pre_commit` 6.1.4** — needed Dart >= 3.9.0. Closes #74.
- **`fl_chart` 1.2.0** — needed `vector_math` 2.2.0 while `flutter_test` pinned 2.1.4, so the constraint looked satisfiable but never was. Closes #76. (`fl_chart` turns out to be unused entirely — see #95.)

## The upgrade silently broke the schema, and fixing it drove the rest

The first attempt regenerated `database.g.dart` as 68 insertions against 527 deletions, and among the losses were both cascade constraints:

```
REFERENCES nas_servers (id) ON DELETE CASCADE
REFERENCES app_configs (id) ON DELETE CASCADE
```

plus the `WritePropagation` rules that cascade deletes into drift's stream queries. Deleting a server would have orphaned its app configs; deleting an app config, its port configs.

The source never changed — `database.dart:36` and `:78` still declare `.references(..., onDelete: KeyAction.cascade)`. The cause was in the `build_runner` output:

```
W SDK language version 3.13.0 is newer than `analyzer` language version 3.12.0
W drift_dev ... line 36: This parameter should be a simple class name
W drift_dev ... line 78: This parameter should be a simple class name
```

`drift_dev` 2.31.0 constrains `analyzer` to `<11.0.0`, pinning it at 10.2.0 — too old to resolve a class reference under Dart 3.13. The generator degraded silently and emitted the columns without their constraints.

Raising `drift`/`drift_dev` to 2.34.x and `dart_pre_commit` to 6.1.4 lets `analyzer` 13.3.0 resolve. Code generation is now warning-free and `database.g.dart` is back to within five insertions and twelve deletions of `main`, none of them touching a constraint, reference or propagation rule.

## That pulls in the sqlite3 v3 migration

drift 2.32+ requires `sqlite3 ^3.1.5`, and `drift_flutter` 0.3.1 depends on `sqlite3_flutter_libs 0.6.0+eol` — a deliberately emptied package. sqlite3 3.x bundles SQLite through Dart build hooks instead of CocoaPods, which is why both `Podfile.lock` files lose their sqlite3 pods entirely.

Checked against the upstream `UPGRADING_TO_V3.md`: none of the migration steps apply here — no `open.overrideFor`, no Android workaround, no direct dependency on `sqlite3_flutter_libs`, and no web target, so the `sqlite3.wasm` step is moot.

## Other changes the new SDK required

`flutter analyze` fails on info and warning level, and the upgrade surfaced 33:

- **`Color.withOpacity` → `withValues(alpha:)`** across 32 call sites in 10 files.
- **drift's `TableMigration` is experimental upstream.** The single use is in a migration that already shipped, so it carries a targeted `// ignore` with the reason.

The environment constraint goes from `^3.8.1` to `^3.9.0`, the real floor the dev dependencies impose. The Flutter tool migrated `analysis_options.yaml` itself to exclude `build/`, `ios/` and `macos/`.

`path_provider_foundation` 2.6.0 became a Dart/FFI implementation declaring only a `dartPluginClass`, so it no longer registers as a native plugin or installs a pod. Its disappearance from `GeneratedPluginRegistrant.swift` and both lockfiles is expected, not a dropped dependency.

## CI cache

The macOS build failed once with:

```
error: file '.../FlutterMacOS.framework/Headers/FlutterPluginRegistrarMacOS.h'
has been modified since the module file '...flutter_secure_storage_macos-....pcm' was built
```

The cache was restoring `build/`, holding Xcode's precompiled Swift modules from a run on Flutter 3.32.6. The version now lives in one `env.FLUTTER_VERSION` shared by the setup step and the cache key — and `build/` is no longer cached at all, since the runner's Xcode can move without any key of ours changing.

## Verification

- `dart run build_runner build` — clean, no warnings
- `flutter analyze` — no issues
- `dart format --set-exit-if-changed .` — no changes
- `flutter test` — **145 passed**, exercising real SQLite through `NativeDatabase.memory()`
- **CI green**, including `flutter build ios` and `flutter build macos` — which is what proves the new hooks-based SQLite bundling links on both Apple platforms

**One thing a green build does not prove:** that the app opens its database on a real device. The bundling mechanism changed, and only launching the app confirms the runtime side. Worth a smoke test before this reaches a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5z1S7zDW147LN1x38h9b1