### PR TITLE
Trim derivable and stale content from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,61 +8,15 @@ TrueNAS Manager - A Flutter application for managing TrueNAS servers on iOS and 
 
 ## Commands
 
-### Development
-- `flutter pub get` - Install dependencies
-- `flutter run` - Run on iOS (default)
-- `flutter run -d macos` - Run on macOS
-- `flutter analyze` - Run static analysis
-- `dart run build_runner build` - Generate database code (required after modifying database schema)
-- `dart format` - Run dart formatter before committing
+- `dart run build_runner build` - required after modifying the drift database schema
+- `dart format` - run before committing
 
-### Building
-- `flutter build ios` - Build iOS app
-- `flutter build macos` - Build macOS app
+## Key Implementation Notes
 
-### Testing
-- `flutter test` - Run all tests
-- `flutter test test/widget_test.dart` - Run specific test file
-
-## Architecture
-
-### State Management
-Uses Provider pattern. Providers are located in `lib/providers/` and manage application state:
-- `server_provider.dart` - Manages server connections and active server state
-- `pool_provider.dart` - Manages storage pool data
-- `dataset_provider.dart` - Manages dataset information
-
-### Data Layer
-Repository pattern with drift (SQLite) database:
-- `lib/services/database_service.dart` - Main database service using drift
-- `lib/models/` - Data models using Equatable for value equality
-- Database schema changes require running `dart run build_runner build`
-
-### UI Structure
-- `lib/screens/` - Full page views (e.g., server list, pool details, dataset management)
-- `lib/widgets/` - Reusable UI components
-- All UI uses Cupertino (iOS-style) widgets exclusively
-
-### Key Implementation Notes
-1. The app supports multiple TrueNAS server connections stored securely in SQLite
+1. All UI uses Cupertino (iOS-style) widgets exclusively - never Material
 2. Passwords live in the native Keychain via `NativeKeychainService`, never in the
    database. Server metadata, including the username, is stored by the repository
    layer: CloudKit on Apple platforms, SQLite elsewhere
-3. Uses dio for HTTP requests to TrueNAS API
-4. Native platform features through iOS/macOS specific implementations
-
-## Current Development Status
-- ✅ Completed: server management, JSON-RPC API client, CloudKit/SQLite repository layer,
-  Keychain + biometrics, pools & datasets, app catalog with live resource usage, file browsing,
-  system stats, macOS tray, `truenas_native_plugins` package, adaptive Cupertino sidebar
-  navigation with go_router (#54)
-- 🚧 In Progress: splitting large screens into smaller widgets (#35), raising test
-  coverage towards 80%
-- 📋 Planned: alerts & push notifications (#25), job monitor (#26), service management (#27),
-  dashboard widgets (#28), system updates (#29), network interfaces (#30), pool health/scrub (#31),
-  mDNS discovery (#39)
-
-See README.md for the user-facing version of this list.
 
 ## Tooling Notes
 - `gtimeout` is used for adding timeouts to bash commands


### PR DESCRIPTION
Remove guidance a session can reconstruct by reading the repo, and fix
two blocks that had drifted out of sync with the code:

- Standard Flutter commands (pub get, run, analyze, build, test) are
  guessable or listed in pubspec.yaml.
- The Architecture section was a directory listing. Its provider list had
  gone stale: it named 3 providers while lib/providers/ holds 9.
- "connections stored securely in SQLite" contradicted the note directly
  below it (and the README): server metadata is CloudKit on Apple
  platforms, SQLite elsewhere.
- dio and the native-platform note are visible in pubspec.yaml.
- The development status roadmap duplicated README.md by its own
  admission and goes stale as issues land; GitHub issues are the source
  of truth.

Kept the non-derivable parts: the build_runner-after-schema-change
requirement, the Cupertino-exclusive rule (promoted out of the removed
Architecture section), the Keychain/CloudKit storage contract, gtimeout,
and all development, testing and Dart directives.

85 -> 40 lines, ~515 fewer tokens loaded into every session.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016nqmiUsXoZTVmNnnXv1zYT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined developer guidance with concise commands and key implementation notes.
  * Added guidance covering code generation, formatting, Cupertino UI, credential storage, and platform-specific metadata persistence.
  * Retained existing utility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->