### PR TITLE
fix(test): move the macOS floor pin to 12.0 raised by the deps bump

### DIFF
--- a/test/project/ios_podfile_test.dart
+++ b/test/project/ios_podfile_test.dart
@@ -93,7 +93,9 @@ void main() {
         r'MACOSX_DEPLOYMENT_TARGET = (\S+);',
       ).allMatches(pbxproj).map((m) => m.group(1)!).toSet();
 
-      expect(versions, equals({'10.14'}));
+      // 12.0: raised from 10.14 by the dependency majors in #115
+      // (flutter_secure_storage 11 / local_auth 3 require it).
+      expect(versions, equals({'12.0'}));
       expect(_uncommentedOsxPlatform(podfile), equals(versions.single));
     });
   });


### PR DESCRIPTION
The parity guard pins the deployment-target literal; #115 legitimately raised the floor (flutter_secure_storage 11 / local_auth 3) but landed without the pin update, breaking CI on main.

Red locally on main, green with the pin moved; only the pinned literal changes — the parity assertion itself is untouched.

https://claude.ai/code/session_012AjZ2K9SgeHg1UomsjzqKB