### PR TITLE
fix(keychain): match synchronizable items in iOS read and update queries

### DIFF
--- a/packages/truenas_native_plugins/ios/Classes/KeychainPlugin.swift
+++ b/packages/truenas_native_plugins/ios/Classes/KeychainPlugin.swift
@@ -131,7 +131,8 @@ public class KeychainPlugin: NSObject, FlutterPlugin {
             let updateQuery: [String: Any] = [
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: service,
-                kSecAttrAccount as String: account
+                kSecAttrAccount as String: account,
+                kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
             ]
             
             let updateAttributes: [String: Any] = [
@@ -166,7 +167,10 @@ public class KeychainPlugin: NSObject, FlutterPlugin {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecReturnData as String: kCFBooleanTrue
+            kSecReturnData as String: kCFBooleanTrue,
+            // Items are stored with kSecAttrSynchronizable=true; a query without
+            // this key matches only non-synchronizable items and misses them.
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
         
         var dataTypeRef: AnyObject?
@@ -230,7 +234,8 @@ public class KeychainPlugin: NSObject, FlutterPlugin {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecMatchLimit as String: kSecMatchLimitOne
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
         
         let status = SecItemCopyMatching(query as CFDictionary, nil)
@@ -256,7 +261,8 @@ public class KeychainPlugin: NSObject, FlutterPlugin {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: kCFBooleanTrue
+            kSecReturnAttributes as String: kCFBooleanTrue,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
         
         var dataTypeRef: AnyObject?

--- a/packages/truenas_native_plugins/macos/Classes/KeychainPlugin.swift
+++ b/packages/truenas_native_plugins/macos/Classes/KeychainPlugin.swift
@@ -121,7 +121,8 @@ public class KeychainPlugin: NSObject, FlutterPlugin {
             let updateQuery: [String: Any] = [
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: service,
-                kSecAttrAccount as String: account
+                kSecAttrAccount as String: account,
+                kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
             ]
             
             let updateAttributes: [String: Any] = [

--- a/test/project/keychain_plugin_query_test.dart
+++ b/test/project/keychain_plugin_query_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/repo_files.dart';
+
+/// The keychain plugins store passwords with `kSecAttrSynchronizable = true`
+/// (iCloud Keychain sync). Apple's keychain matching EXCLUDES synchronizable
+/// items from any query that does not itself carry a `kSecAttrSynchronizable`
+/// key, so every read or update query in the plugin must pass
+/// `kSecAttrSynchronizableAny` — otherwise a just-saved password is invisible
+/// (errSecItemNotFound) and the app dead-ends on "Authentication Required".
+///
+/// The macOS copy of the plugin has carried this attribute all along, which is
+/// why the bug never surfaced in desktop development; the iOS copy shipped
+/// without it in v0.1.0. This guard keeps both copies honest.
+void main() {
+  final repo = LocalRepoFileReader();
+
+  const plugins = [
+    'packages/truenas_native_plugins/ios/Classes/KeychainPlugin.swift',
+    'packages/truenas_native_plugins/macos/Classes/KeychainPlugin.swift',
+  ];
+
+  for (final path in plugins) {
+    group(path, () {
+      test(
+        'every SecItemCopyMatching/SecItemUpdate query handles synchronizable items',
+        () {
+          final source = repo.read(path);
+          final callSites = RegExp(
+            r'SecItem(CopyMatching|Update)\(',
+          ).allMatches(source).toList();
+          expect(
+            callSites,
+            isNotEmpty,
+            reason: 'expected keychain read/update call sites in $path',
+          );
+
+          for (final call in callSites) {
+            // The query dictionary is declared immediately above its use in
+            // this file's style; the preceding window must carry the
+            // synchronizable-agnostic match key.
+            final windowStart = call.start < 900 ? 0 : call.start - 900;
+            final window = source.substring(windowStart, call.start);
+            expect(
+              window,
+              contains('kSecAttrSynchronizableAny'),
+              reason:
+                  'query for ${call.group(0)} at offset ${call.start} in '
+                  '$path does not match synchronizable items — a password '
+                  'stored with kSecAttrSynchronizable=true will not be found',
+            );
+          }
+        },
+      );
+    });
+  }
+}


### PR DESCRIPTION
## Problem

TestFlight v0.1.0 report: after adding a server, the app dead-ends on "Authentication Required" and the Authenticate button does nothing ("Load user info" is equally dead — no credentials means no API client).

## Root cause

Passwords are stored with `kSecAttrSynchronizable=true` (iCloud Keychain sync), but Apple's keychain matching **excludes synchronizable items from any query that doesn't carry a `kSecAttrSynchronizable` key**. The iOS plugin's `getPassword`/`hasPassword`/`getAllServerIds` queries omitted it, so a just-saved password read back as `errSecItemNotFound` — and retrying re-ran the same failing read forever. The macOS copy of the plugin has carried `kSecAttrSynchronizableAny` on its reads all along (why desktop development never caught it); only its duplicate-item update branch shared the bug.

## Fix

Add `kSecAttrSynchronizableAny` to every read/update query in both platform copies — the same key the store path's delete query already used.

TDD: `test/project/keychain_plugin_query_test.dart` is a repo-file guard (same pattern as `ios_podfile_test.dart`) that walks every `SecItemCopyMatching`/`SecItemUpdate` call site in both plugin copies and fails if its query can't match synchronizable items. Red on the unpatched iOS file (and macOS's update branch), green with the fix.

## Tests

- New guard test: red before, green after
- `flutter test test/project/` green, `flutter analyze` 0 issues

Fixes the v0.1.0/v0.1.1 TestFlight credential dead-end; ships with the next release cut.

https://claude.ai/code/session_012AjZ2K9SgeHg1UomsjzqKB