### PR TITLE
fix: reconnect and refresh when the app returns to the foreground

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/providers/server_provider.dart';
+import 'package:truehub/widgets/app_lifecycle_reconnector.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/dataset_provider.dart';
 import 'package:truehub/providers/app_provider.dart';
@@ -173,13 +176,21 @@ class _TrueNASManagerAppState extends State<TrueNASManagerApp> {
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoApp.router(
-      title: 'TrueNAS Manager',
-      theme: const CupertinoThemeData(
-        primaryColor: CupertinoColors.systemBlue,
-        brightness: Brightness.light,
+    // No timer runs while the process is suspended, so a connection the OS
+    // tore down in the background stays dead until something asks for it.
+    // Returning to the foreground is that trigger.
+    return AppLifecycleReconnector(
+      onResumed: () {
+        unawaited(context.read<ServerProvider>().refreshConnection());
+      },
+      child: CupertinoApp.router(
+        title: 'TrueNAS Manager',
+        theme: const CupertinoThemeData(
+          primaryColor: CupertinoColors.systemBlue,
+          brightness: Brightness.light,
+        ),
+        routerConfig: appRouter,
       ),
-      routerConfig: appRouter,
     );
   }
 }

--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -372,7 +372,15 @@ class ServerProvider extends ChangeNotifier {
     // Every pooled client matters, not just the selected server's: other
     // providers hold clients the OS dropped just the same. One round of
     // recovery covers them all and reports per-server failures.
+    final client = _apiClient;
     final failures = await ApiClientManager.ensureAllConnectionsAlive();
+
+    // Recovery is asynchronous: the user may have switched servers (or the
+    // client may have been recreated) while it ran. Applying a result for the
+    // previous selection to the current one would report the wrong state.
+    if (!identical(_apiClient, client) || _selectedServer?.id != server.id) {
+      return;
+    }
 
     final failure = failures[server.id];
     if (failure == null) {

--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -366,18 +366,23 @@ class ServerProvider extends ChangeNotifier {
   /// Revives the connection after the app was suspended and refreshes what the
   /// screens display. Safe to call when nothing is connected.
   Future<void> refreshConnection() async {
-    final client = _apiClient;
-    if (client == null) return;
+    final server = _selectedServer;
+    if (_apiClient == null || server == null) return;
 
-    try {
-      await client.ensureConnectionAlive();
+    // Every pooled client matters, not just the selected server's: other
+    // providers hold clients the OS dropped just the same. One round of
+    // recovery covers them all and reports per-server failures.
+    final failures = await ApiClientManager.ensureAllConnectionsAlive();
+
+    final failure = failures[server.id];
+    if (failure == null) {
       _authState = AuthenticationState.authenticated;
       _authError = null;
-    } catch (e) {
+    } else {
       _authState = AuthenticationState.failed;
-      _authError = 'Connection lost: ${e.toString()}';
+      _authError = 'Connection lost: $failure';
       if (kDebugMode) {
-        print('ServerProvider: Failed to refresh connection: $e');
+        print('ServerProvider: Failed to refresh connection: $failure');
       }
     }
 

--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -363,6 +363,32 @@ class ServerProvider extends ChangeNotifier {
     }
   }
 
+  /// Revives the connection after the app was suspended and refreshes what the
+  /// screens display. Safe to call when nothing is connected.
+  Future<void> refreshConnection() async {
+    final client = _apiClient;
+    if (client == null) return;
+
+    try {
+      await client.ensureConnectionAlive();
+      _authState = AuthenticationState.authenticated;
+      _authError = null;
+    } catch (e) {
+      _authState = AuthenticationState.failed;
+      _authError = 'Connection lost: ${e.toString()}';
+      if (kDebugMode) {
+        print('ServerProvider: Failed to refresh connection: $e');
+      }
+    }
+
+    _emitAuthStatus();
+    notifyListeners();
+
+    if (_authState == AuthenticationState.authenticated) {
+      await loadServerHealth();
+    }
+  }
+
   Future<void> loadServerHealth() async {
     if (_apiClient == null) return;
 

--- a/lib/services/api_client_interface.dart
+++ b/lib/services/api_client_interface.dart
@@ -71,6 +71,11 @@ abstract class ApiClientInterface {
 
   // System stats subscription methods
   Stream<SystemStats> get systemStatsStream;
+
+  /// Verify the connection is still usable and recover it if it is not.
+  /// Called when the app returns to the foreground.
+  Future<void> ensureConnectionAlive();
+
   Future<void> subscribeToSystemStats();
   Future<void> unsubscribeFromSystemStats();
 

--- a/lib/services/api_client_manager.dart
+++ b/lib/services/api_client_manager.dart
@@ -40,6 +40,10 @@ class ApiClientManager {
     return instance.closeClient(serverId);
   }
 
+  static Future<Map<String, Object>> ensureAllConnectionsAlive() async {
+    return instance.ensureAllConnectionsAlive();
+  }
+
   static Future<void> closeAllClients() async {
     return instance.closeAllClients();
   }

--- a/lib/services/api_client_manager_impl.dart
+++ b/lib/services/api_client_manager_impl.dart
@@ -158,6 +158,28 @@ class ApiClientManagerImpl implements ApiClientManagerInterface {
   }
 
   @override
+  Future<Map<String, Object>> ensureAllConnectionsAlive() async {
+    final failures = <String, Object>{};
+
+    await Future.wait(
+      getActiveServerIds().map((serverId) async {
+        final client = getExistingClient(serverId);
+        if (client == null) return;
+        try {
+          await client.ensureConnectionAlive();
+        } catch (e) {
+          failures[serverId] = e;
+          if (kDebugMode) {
+            print('ApiClientManager: Recovery failed for $serverId: $e');
+          }
+        }
+      }),
+    );
+
+    return failures;
+  }
+
+  @override
   Future<void> closeAllClients() async {
     if (kDebugMode) {
       print('ApiClientManager: Closing all clients');

--- a/lib/services/api_client_manager_interface.dart
+++ b/lib/services/api_client_manager_interface.dart
@@ -20,6 +20,13 @@ abstract class ApiClientManagerInterface {
   /// Close all active clients
   Future<void> closeAllClients();
 
+  /// Verifies every pooled client's connection and recovers the ones the OS
+  /// dropped while the app was suspended.
+  ///
+  /// One unreachable server never prevents the others from recovering, so
+  /// failures are returned per server id rather than thrown.
+  Future<Map<String, Object>> ensureAllConnectionsAlive();
+
   /// Get an existing client without creating a new one
   TrueNasApiClient? getExistingClient(String serverId);
 

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -46,7 +46,7 @@ class TrueNasApiClient implements ApiClientInterface {
   bool get _hasLiveConnection => _client != null && !_client!.isClosed;
 
   Future<void> _ensureConnected() async {
-    if (_client != null && !_client!.isClosed) {
+    if (_hasLiveConnection) {
       return;
     }
 
@@ -81,18 +81,34 @@ class TrueNasApiClient implements ApiClientInterface {
         protocols: ['json-rpc'],
       );
 
+      // WebSocketChannel.connect is lazy: without awaiting readiness a failed
+      // handshake surfaces as an unhandled asynchronous error instead of a
+      // failure the caller can act on.
+      await _wsChannel!.ready.timeout(const Duration(seconds: 15));
+
       _client = Peer(_wsChannel!.cast<String>());
 
       // Register method to handle collection_update notifications from server
       _setupCollectionUpdateHandler();
 
       // Start listening for responses with error handling
-      _client!.listen().catchError((error) {
-        if (kDebugMode) {
-          print('TrueNAS API: WebSocket error: $error');
-        }
-        throw _handleConnectionError(error);
-      });
+      // Socket-level failures arrive here asynchronously, with no caller to
+      // receive them: rethrowing would only produce an unhandled zone error.
+      // Record the state instead - the next request (or the resume hook) sees
+      // the closed client and recovers.
+      unawaited(
+        _client!.listen().catchError((error) {
+          if (kDebugMode) {
+            print('TrueNAS API: WebSocket error: $error');
+          }
+          _isAuthenticated = false;
+          _connectionStatusProvider?.updateConnectionState(
+            _server.id,
+            TrueNASConnectionState.error,
+            error: error.toString(),
+          );
+        }),
+      );
 
       _isAuthenticated = false;
       if (kDebugMode) {
@@ -102,6 +118,15 @@ class TrueNasApiClient implements ApiClientInterface {
       if (kDebugMode) {
         print('TrueNAS API: Connection failed: $e');
       }
+
+      // Drop the half-open channel. Keeping it means a later close() awaits a
+      // handshake that never completed, which never returns.
+      final failedChannel = _wsChannel;
+      _wsChannel = null;
+      _client = null;
+      _isAuthenticated = false;
+      unawaited(failedChannel?.sink.close().catchError((_) {}));
+
       _connectionStatusProvider?.updateConnectionState(
         _server.id,
         TrueNASConnectionState.error,
@@ -138,10 +163,6 @@ class TrueNasApiClient implements ApiClientInterface {
   }
 
   Future<void> _sendKeepalivePing() async {
-    if (!_keepaliveEnabled) {
-      return;
-    }
-
     // A closed socket is precisely the case that needs recovering. Returning
     // here (as this used to) left the client dead until something else
     // happened to issue a request.
@@ -207,7 +228,17 @@ class TrueNasApiClient implements ApiClientInterface {
     }
   }
 
-  Future<void> _handleKeepaliveTimeout() async {
+  /// Guards against two triggers (the keepalive timer and the app-resume
+  /// hook) starting overlapping reconnects, which would open two sessions.
+  Future<void>? _recovery;
+
+  Future<void> _handleKeepaliveTimeout() {
+    return _recovery ??= _recoverConnection().whenComplete(() {
+      _recovery = null;
+    });
+  }
+
+  Future<void> _recoverConnection() async {
     _awaitingPong = false;
 
     if (kDebugMode) {
@@ -263,12 +294,20 @@ class TrueNasApiClient implements ApiClientInterface {
   /// the process is suspended, so nothing else notices the dead socket.
   @override
   Future<void> ensureConnectionAlive() async {
-    if (_hasLiveConnection && _isAuthenticated) {
-      await _sendKeepalivePing();
-      return;
-    }
+    // _sendKeepalivePing already owns the "is this connection usable, and
+    // recover it if not" decision; don't restate it here.
+    await _sendKeepalivePing();
 
-    await _handleKeepaliveTimeout();
+    // Recovery reports its own failures to the connection status provider and
+    // does not rethrow, because the periodic timer must not die on a blip. A
+    // caller that asked for a usable connection needs the bad news.
+    if (!_hasLiveConnection || !_isAuthenticated) {
+      throw ConnectionException(
+        ConnectionError.networkUnreachable(
+          details: 'Could not restore the connection to ${_server.name}',
+        ),
+      );
+    }
   }
 
   /// Re-subscribes to the streams the UI had asked for before the connection
@@ -280,14 +319,18 @@ class TrueNasApiClient implements ApiClientInterface {
     if (wantsSystemStats) {
       _isSubscribedToRealtime = false;
       _realtimeSubscriptionId = null;
-      await subscribeToSystemStats();
     }
-
     if (wantsAppStats) {
       _isSubscribedToAppStats = false;
       _appStatsSubscriptionId = null;
-      await subscribeToAppStats();
     }
+
+    // Independent RPCs over an established session; no reason to serialise
+    // them on a path where round trips already stack up.
+    await Future.wait([
+      if (wantsSystemStats) subscribeToSystemStats(),
+      if (wantsAppStats) subscribeToAppStats(),
+    ]);
   }
 
   @override
@@ -1023,7 +1066,7 @@ class TrueNasApiClient implements ApiClientInterface {
     }
 
     try {
-      if (_client != null && !_client!.isClosed) {
+      if (_hasLiveConnection) {
         await _client!.sendRequest('core.unsubscribe', [
           _realtimeSubscriptionId!,
         ]);
@@ -1103,7 +1146,7 @@ class TrueNasApiClient implements ApiClientInterface {
     }
 
     try {
-      if (_client != null && !_client!.isClosed) {
+      if (_hasLiveConnection) {
         await _client!.sendRequest('core.unsubscribe', [
           _appStatsSubscriptionId!,
         ]);

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -29,10 +29,16 @@ class TrueNasApiClient implements ApiClientInterface {
   String? _realtimeSubscriptionId;
   bool _isSubscribedToRealtime = false;
 
+  /// What the UI asked for, as opposed to what is currently live on the
+  /// socket. A subscription that fails to restore is still wanted, so it must
+  /// outlive the connection that carried it.
+  bool _wantsSystemStats = false;
+
   // App stats subscription management
   StreamController<Map<String, AppResourceUsage>>? _appStatsController;
   String? _appStatsSubscriptionId;
   bool _isSubscribedToAppStats = false;
+  bool _wantsAppStats = false;
 
   // Keepalive mechanism
   Timer? _keepaliveTimer;
@@ -250,8 +256,14 @@ class TrueNasApiClient implements ApiClientInterface {
       TrueNASConnectionState.reconnecting,
     );
 
-    // Reset connection state
+    // Reset connection state. The subscriptions belonged to the socket that
+    // just died; what the UI wants (_wantsSystemStats / _wantsAppStats) is
+    // deliberately untouched so it can be restored below.
     _isAuthenticated = false;
+    _isSubscribedToRealtime = false;
+    _realtimeSubscriptionId = null;
+    _isSubscribedToAppStats = false;
+    _appStatsSubscriptionId = null;
 
     try {
       // Close existing connection
@@ -292,11 +304,31 @@ class TrueNasApiClient implements ApiClientInterface {
   /// re-authenticates and restores active subscriptions when it is not.
   /// Call this when the app returns to the foreground - no timer fires while
   /// the process is suspended, so nothing else notices the dead socket.
+  /// True when the UI asked for a stream that is not live on this socket.
+  bool get _hasMissingSubscription =>
+      (_wantsSystemStats && !_isSubscribedToRealtime) ||
+      (_wantsAppStats && !_isSubscribedToAppStats);
+
   @override
   Future<void> ensureConnectionAlive() async {
     // _sendKeepalivePing already owns the "is this connection usable, and
     // recover it if not" decision; don't restate it here.
     await _sendKeepalivePing();
+
+    // A healthy socket is not enough: a stream the UI wants may have failed to
+    // restore on an earlier attempt, and the ping cannot see that. A refusal
+    // here is a partial failure - the connection is fine and the intent is
+    // kept, so the next attempt retries it - and must not be reported as a
+    // lost connection.
+    if (_hasLiveConnection && _isAuthenticated && _hasMissingSubscription) {
+      try {
+        await _restoreSubscriptions();
+      } catch (e) {
+        if (kDebugMode) {
+          print('TrueNAS API: Subscription restore deferred: $e');
+        }
+      }
+    }
 
     // Recovery reports its own failures to the connection status provider and
     // does not rethrow, because the periodic timer must not die on a blip. A
@@ -313,23 +345,13 @@ class TrueNasApiClient implements ApiClientInterface {
   /// Re-subscribes to the streams the UI had asked for before the connection
   /// was lost. The stale subscription ids belong to the dead socket.
   Future<void> _restoreSubscriptions() async {
-    final wantsSystemStats = _isSubscribedToRealtime;
-    final wantsAppStats = _isSubscribedToAppStats;
-
-    if (wantsSystemStats) {
-      _isSubscribedToRealtime = false;
-      _realtimeSubscriptionId = null;
-    }
-    if (wantsAppStats) {
-      _isSubscribedToAppStats = false;
-      _appStatsSubscriptionId = null;
-    }
-
     // Independent RPCs over an established session; no reason to serialise
-    // them on a path where round trips already stack up.
+    // them on a path where round trips already stack up. The intent flags stay
+    // set: a restore that fails here is retried by the next recovery.
     await Future.wait([
-      if (wantsSystemStats) subscribeToSystemStats(),
-      if (wantsAppStats) subscribeToAppStats(),
+      if (_wantsSystemStats && !_isSubscribedToRealtime)
+        subscribeToSystemStats(),
+      if (_wantsAppStats && !_isSubscribedToAppStats) subscribeToAppStats(),
     ]);
   }
 
@@ -1023,12 +1045,17 @@ class TrueNasApiClient implements ApiClientInterface {
     // A subscription only exists for as long as the socket that created it.
     // After the connection drops - which is what the OS does to a backgrounded
     // app - the flag is stale and re-subscribing is exactly what's needed.
+    _wantsSystemStats = true;
+
     if (_isSubscribedToRealtime && _hasLiveConnection) {
       if (kDebugMode) {
         print('TrueNAS API: Already subscribed to realtime stats');
       }
       return;
     }
+
+    _isSubscribedToRealtime = false;
+    _realtimeSubscriptionId = null;
 
     try {
       await _ensureAuthenticated();
@@ -1082,6 +1109,7 @@ class TrueNasApiClient implements ApiClientInterface {
         print('TrueNAS API: Error unsubscribing from system stats: $e');
       }
     } finally {
+      _wantsSystemStats = false;
       _isSubscribedToRealtime = false;
       _realtimeSubscriptionId = null;
       await _systemStatsController?.close();
@@ -1103,6 +1131,8 @@ class TrueNasApiClient implements ApiClientInterface {
 
   @override
   Future<void> subscribeToAppStats() async {
+    _wantsAppStats = true;
+
     if (_isSubscribedToAppStats && _hasLiveConnection) {
       if (kDebugMode) {
         print('TrueNAS API: Already subscribed to app stats');
@@ -1162,6 +1192,7 @@ class TrueNasApiClient implements ApiClientInterface {
         print('TrueNAS API: Error unsubscribing from app stats: $e');
       }
     } finally {
+      _wantsAppStats = false;
       _isSubscribedToAppStats = false;
       _appStatsSubscriptionId = null;
       await _appStatsController?.close();

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -42,6 +42,9 @@ class TrueNasApiClient implements ApiClientInterface {
 
   TrueNasApiClient(this._server, [this._connectionStatusProvider]);
 
+  /// Whether the JSON-RPC socket is currently usable.
+  bool get _hasLiveConnection => _client != null && !_client!.isClosed;
+
   Future<void> _ensureConnected() async {
     if (_client != null && !_client!.isClosed) {
       return;
@@ -135,7 +138,15 @@ class TrueNasApiClient implements ApiClientInterface {
   }
 
   Future<void> _sendKeepalivePing() async {
-    if (_client == null || _client!.isClosed || !_isAuthenticated) {
+    if (!_keepaliveEnabled) {
+      return;
+    }
+
+    // A closed socket is precisely the case that needs recovering. Returning
+    // here (as this used to) left the client dead until something else
+    // happened to issue a request.
+    if (!_hasLiveConnection || !_isAuthenticated) {
+      await _handleKeepaliveTimeout();
       return;
     }
 
@@ -219,6 +230,12 @@ class TrueNasApiClient implements ApiClientInterface {
       // Re-establish connection
       await _ensureConnected();
       await _ensureAuthenticated();
+      await _restoreSubscriptions();
+
+      _connectionStatusProvider?.updateConnectionState(
+        _server.id,
+        TrueNASConnectionState.connected,
+      );
 
       if (kDebugMode) {
         print('TrueNAS API: Successfully reconnected after keepalive timeout');
@@ -234,6 +251,42 @@ class TrueNasApiClient implements ApiClientInterface {
       );
       // Stop keepalive on repeated failures to avoid continuous retry loops
       _stopKeepalive();
+    }
+  }
+
+  /// Makes the client usable again after the connection may have died while
+  /// the app was suspended.
+  ///
+  /// Cheap when the socket is healthy (a single ping); reconnects,
+  /// re-authenticates and restores active subscriptions when it is not.
+  /// Call this when the app returns to the foreground - no timer fires while
+  /// the process is suspended, so nothing else notices the dead socket.
+  @override
+  Future<void> ensureConnectionAlive() async {
+    if (_hasLiveConnection && _isAuthenticated) {
+      await _sendKeepalivePing();
+      return;
+    }
+
+    await _handleKeepaliveTimeout();
+  }
+
+  /// Re-subscribes to the streams the UI had asked for before the connection
+  /// was lost. The stale subscription ids belong to the dead socket.
+  Future<void> _restoreSubscriptions() async {
+    final wantsSystemStats = _isSubscribedToRealtime;
+    final wantsAppStats = _isSubscribedToAppStats;
+
+    if (wantsSystemStats) {
+      _isSubscribedToRealtime = false;
+      _realtimeSubscriptionId = null;
+      await subscribeToSystemStats();
+    }
+
+    if (wantsAppStats) {
+      _isSubscribedToAppStats = false;
+      _appStatsSubscriptionId = null;
+      await subscribeToAppStats();
     }
   }
 
@@ -329,7 +382,10 @@ class TrueNasApiClient implements ApiClientInterface {
   }
 
   Future<void> _ensureAuthenticated() async {
-    if (_isAuthenticated) return;
+    // Authentication belongs to a socket: once that socket is gone, so is the
+    // session, no matter what the flag from the previous connection says.
+    if (_isAuthenticated && _hasLiveConnection) return;
+    _isAuthenticated = false;
 
     try {
       await _ensureConnected();
@@ -921,7 +977,10 @@ class TrueNasApiClient implements ApiClientInterface {
 
   @override
   Future<void> subscribeToSystemStats() async {
-    if (_isSubscribedToRealtime) {
+    // A subscription only exists for as long as the socket that created it.
+    // After the connection drops - which is what the OS does to a backgrounded
+    // app - the flag is stale and re-subscribing is exactly what's needed.
+    if (_isSubscribedToRealtime && _hasLiveConnection) {
       if (kDebugMode) {
         print('TrueNAS API: Already subscribed to realtime stats');
       }
@@ -1001,7 +1060,7 @@ class TrueNasApiClient implements ApiClientInterface {
 
   @override
   Future<void> subscribeToAppStats() async {
-    if (_isSubscribedToAppStats) {
+    if (_isSubscribedToAppStats && _hasLiveConnection) {
       if (kDebugMode) {
         print('TrueNAS API: Already subscribed to app stats');
       }

--- a/lib/widgets/app_lifecycle_reconnector.dart
+++ b/lib/widgets/app_lifecycle_reconnector.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/widgets.dart';
+
+/// Notifies when the app returns to the foreground.
+///
+/// No timer runs while the process is suspended, so a connection torn down by
+/// the OS in the background goes unnoticed until something asks for it. This
+/// widget provides that trigger: wrap the app once and recover the connection
+/// in [onResumed].
+class AppLifecycleReconnector extends StatefulWidget {
+  const AppLifecycleReconnector({
+    super.key,
+    required this.onResumed,
+    required this.child,
+  });
+
+  /// Called on every transition back to [AppLifecycleState.resumed].
+  final VoidCallback onResumed;
+
+  final Widget child;
+
+  @override
+  State<AppLifecycleReconnector> createState() =>
+      _AppLifecycleReconnectorState();
+}
+
+class _AppLifecycleReconnectorState extends State<AppLifecycleReconnector>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      widget.onResumed();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/test/helpers/mock_api_client_manager.dart
+++ b/test/helpers/mock_api_client_manager.dart
@@ -76,6 +76,12 @@ class MockApiClientManager implements ApiClientManagerInterface {
   }
 
   @override
+  Future<Map<String, Object>> ensureAllConnectionsAlive() async {
+    methodCalls.add('ensureAllConnectionsAlive');
+    return <String, Object>{};
+  }
+
+  @override
   Future<void> closeAllClients() async {
     methodCalls.add('closeAllClients');
     _mockClients.clear();

--- a/test/services/connection_recovery_test.dart
+++ b/test/services/connection_recovery_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
+import 'package:stream_channel/stream_channel.dart';
+import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/services/truenas_api_client.dart';
+import 'package:web_socket_channel/io.dart';
+
+/// A minimal stand-in for a TrueNAS middleware WebSocket endpoint.
+///
+/// It counts the calls the client makes so a test can assert that a
+/// subscription was actually re-established, and it can drop the socket the
+/// way iOS does when an app is suspended in the background.
+class FakeTrueNasServer {
+  FakeTrueNasServer._(this._httpServer);
+
+  final HttpServer _httpServer;
+  final List<WebSocket> _sockets = [];
+  int loginCount = 0;
+  int subscribeCount = 0;
+  int pingCount = 0;
+
+  static Future<FakeTrueNasServer> start() async {
+    final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final server = FakeTrueNasServer._(httpServer);
+    unawaited(server._acceptConnections());
+    return server;
+  }
+
+  int get port => _httpServer.port;
+
+  Future<void> _acceptConnections() async {
+    await for (final request in _httpServer) {
+      final socket = await WebSocketTransformer.upgrade(
+        request,
+        protocolSelector: (protocols) => 'json-rpc',
+      );
+      _sockets.add(socket);
+      _serve(IOWebSocketChannel(socket).cast<String>());
+    }
+  }
+
+  void _serve(StreamChannel<String> channel) {
+    final peer = json_rpc.Peer(channel)
+      ..registerMethod('auth.login', (json_rpc.Parameters _) {
+        loginCount++;
+        return true;
+      })
+      ..registerMethod('core.subscribe', (json_rpc.Parameters _) {
+        subscribeCount++;
+        return 'subscription-$subscribeCount';
+      })
+      ..registerMethod('core.unsubscribe', (json_rpc.Parameters _) => true)
+      ..registerMethod('core.ping', (json_rpc.Parameters _) {
+        pingCount++;
+        return 'pong';
+      });
+    unawaited(peer.listen().catchError((_) {}));
+  }
+
+  /// Kills the live socket(s) without a graceful protocol shutdown - what the
+  /// device does to a backgrounded app's connection.
+  Future<void> dropConnections() async {
+    for (final socket in _sockets) {
+      await socket.close();
+    }
+    _sockets.clear();
+    // Give the client's stream a turn to observe the closure.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+
+  Future<void> stop() async {
+    await dropConnections();
+    await _httpServer.close(force: true);
+  }
+}
+
+void main() {
+  late FakeTrueNasServer server;
+  late TrueNasApiClient client;
+
+  setUp(() async {
+    server = await FakeTrueNasServer.start();
+    client = TrueNasApiClient(
+      NasServer(
+        id: 'recovery-test',
+        name: 'Recovery Test',
+        host: '127.0.0.1',
+        port: server.port,
+        useHttps: false,
+        username: 'user',
+        password: 'pw',
+        localUrl: null,
+        // Empty list keeps NetworkService off the platform channels.
+        trustedWifiSsids: const [],
+        isDefault: false,
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await client.close();
+    await server.stop();
+  });
+
+  test(
+    'ensureConnectionAlive restores a connection dropped in the background',
+    () async {
+      await client.subscribeToSystemStats();
+      expect(server.loginCount, 1);
+      expect(server.subscribeCount, 1);
+
+      // Backgrounded: the OS tears the socket down. No timer can help here -
+      // the keepalive ping sees a closed client and has nothing to ping.
+      await server.dropConnections();
+
+      // Foregrounded: the app asks the client to make itself usable again.
+      await client.ensureConnectionAlive();
+
+      expect(
+        server.loginCount,
+        2,
+        reason: 'the client must re-authenticate on the new socket',
+      );
+      expect(
+        server.subscribeCount,
+        2,
+        reason: 'active subscriptions must be restored, or stats stay frozen',
+      );
+    },
+  );
+
+  test(
+    'subscribeToSystemStats re-subscribes after the connection was lost',
+    () async {
+      await client.subscribeToSystemStats();
+      expect(server.subscribeCount, 1);
+
+      // The app goes to the background; iOS tears the socket down.
+      await server.dropConnections();
+
+      // Coming back to the foreground, the screen asks for stats again. The
+      // subscription lives on the dead socket, so it has to be re-established
+      // - not skipped because a stale flag still says "already subscribed".
+      await client.subscribeToSystemStats();
+
+      expect(
+        server.subscribeCount,
+        2,
+        reason:
+            'the stats subscription must be re-established on the new '
+            'connection, otherwise the screen keeps showing frozen values',
+      );
+    },
+  );
+}

--- a/test/services/connection_recovery_test.dart
+++ b/test/services/connection_recovery_test.dart
@@ -22,6 +22,10 @@ class FakeTrueNasServer {
   int subscribeCount = 0;
   int pingCount = 0;
 
+  /// Makes core.subscribe fail, the way a server still starting up rejects
+  /// subscriptions for a while after a reconnect.
+  bool failSubscribes = false;
+
   static Future<FakeTrueNasServer> start() async {
     final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     final server = FakeTrueNasServer._(httpServer);
@@ -49,6 +53,9 @@ class FakeTrueNasServer {
         return true;
       })
       ..registerMethod('core.subscribe', (json_rpc.Parameters _) {
+        if (failSubscribes) {
+          throw json_rpc.RpcException(1, 'subscription refused');
+        }
         subscribeCount++;
         return 'subscription-$subscribeCount';
       })
@@ -128,6 +135,40 @@ void main() {
         server.subscribeCount,
         2,
         reason: 'active subscriptions must be restored, or stats stay frozen',
+      );
+    },
+  );
+
+  test(
+    'a subscription that fails to restore is retried on the next resume',
+    () async {
+      await client.subscribeToSystemStats();
+      expect(server.subscribeCount, 1);
+
+      await server.dropConnections();
+      server.failSubscribes = true;
+
+      // First resume: the socket comes back, but the server refuses the
+      // subscription for now.
+      await client.ensureConnectionAlive();
+      expect(
+        server.subscribeCount,
+        1,
+        reason: 'a refused subscription must not count as established',
+      );
+
+      // The server accepts subscriptions again; the stream the UI asked for is
+      // still wanted, so the next resume has to attempt it rather than treat a
+      // healthy socket as good enough.
+      server.failSubscribes = false;
+      await client.ensureConnectionAlive();
+
+      expect(
+        server.subscribeCount,
+        2,
+        reason:
+            'a subscription the UI asked for must survive a failed restore, '
+            'otherwise the stream stays frozen while recovery reports success',
       );
     },
   );

--- a/test/services/connection_recovery_test.dart
+++ b/test/services/connection_recovery_test.dart
@@ -132,6 +132,44 @@ void main() {
     },
   );
 
+  test('concurrent recovery attempts reconnect only once', () async {
+    await client.subscribeToSystemStats();
+    expect(server.loginCount, 1);
+
+    await server.dropConnections();
+
+    // The resume hook and the keepalive timer can both notice the dead socket
+    // at the same moment; that must not open two sessions.
+    await Future.wait([
+      client.ensureConnectionAlive(),
+      client.ensureConnectionAlive(),
+      client.ensureConnectionAlive(),
+    ]);
+
+    expect(
+      server.loginCount,
+      2,
+      reason: 'overlapping recovery attempts must share one reconnect',
+    );
+    expect(server.subscribeCount, 2);
+  });
+
+  test(
+    'ensureConnectionAlive reports a failed recovery to its caller',
+    () async {
+      await client.subscribeToSystemStats();
+
+      // The server is gone entirely - recovery cannot succeed, and the caller
+      // has to learn that instead of being told everything is fine.
+      await server.stop();
+
+      await expectLater(
+        client.ensureConnectionAlive(),
+        throwsA(isA<Exception>()),
+      );
+    },
+  );
+
   test(
     'subscribeToSystemStats re-subscribes after the connection was lost',
     () async {

--- a/test/widgets/app_lifecycle_reconnector_test.dart
+++ b/test/widgets/app_lifecycle_reconnector_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/widgets/app_lifecycle_reconnector.dart';
+
+void main() {
+  Future<void> pumpReconnector(
+    WidgetTester tester,
+    VoidCallback onResumed,
+  ) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: AppLifecycleReconnector(
+          onResumed: onResumed,
+          child: const Text('content'),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('calls onResumed when the app returns to the foreground', (
+    tester,
+  ) async {
+    var resumes = 0;
+    await pumpReconnector(tester, () => resumes++);
+
+    expect(resumes, 0, reason: 'mounting alone is not a resume');
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    expect(resumes, 0);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    expect(resumes, 1);
+  });
+
+  testWidgets('reports every foreground transition, not just the first', (
+    tester,
+  ) async {
+    var resumes = 0;
+    await pumpReconnector(tester, () => resumes++);
+
+    for (var i = 0; i < 3; i++) {
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+    }
+
+    expect(resumes, 3);
+  });
+
+  testWidgets('renders its child', (tester) async {
+    await pumpReconnector(tester, () {});
+    expect(find.text('content'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Problem

Reported from TestFlight: re-foregrounding the server detail screen doesn't refresh the connection — the offline badge appears and the stats stay frozen at their last values.

## Root cause

Connection state outlived the socket it belonged to. When the OS tears down a suspended app's connection:

1. `_isSubscribedToRealtime` stayed `true`, so re-subscribing was a silent "already subscribed" no-op — stats could never resume.
2. `_isAuthenticated` stayed `true`, so the reconnect path tried to talk over the dead peer.
3. `_sendKeepalivePing()` returned early on a closed client — the one path that could have recovered gave up exactly when recovery was needed. And no timer runs while the process is suspended, so nothing noticed at all.

## Fix

- Connection-dependent state (`auth`, subscriptions) is now tied to a live socket.
- Reconnects restore the subscriptions the UI asked for, in parallel.
- `ensureConnectionAlive()` on `ApiClientInterface`; overlapping attempts share one in-flight reconnect and a failed recovery is reported to the caller.
- `ApiClientManager.ensureAllConnectionsAlive()` recovers every pooled client (other providers hold clients too), reporting failures per server.
- `AppLifecycleReconnector` at the app root triggers it on every foreground transition.

Two latent faults surfaced while testing: a socket error handler that rethrew into an unhandled zone error, and a half-open channel retained after a failed handshake whose `close()` never returned (a hang).

## Tests

`test/services/connection_recovery_test.dart` drives a fake TrueNAS WebSocket endpoint and drops the socket the way a suspended app loses it: re-subscribe after loss, recovery on resume, single-flight under concurrency, and failure propagation. Plus widget tests for the lifecycle observer. Each was red before its fix.

Full suite 227/227, `flutter analyze` clean, pre-commit hook run un-bypassed.

https://claude.ai/code/session_012AjZ2K9SgeHg1UomsjzqKB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically restores server connections when the app returns to the foreground.
  * Re-establishes subscriptions and refreshes server health after successful recovery.
  * Handles multiple server connections independently, so one failed recovery does not block others.

* **Bug Fixes**
  * Improves authentication and subscription handling after temporary connection loss.
  * Prevents duplicate recovery attempts during simultaneous connection failures.

* **Tests**
  * Added coverage for reconnection, subscription restoration, failed recovery, and app lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->