### PR TITLE
Enable the common Claude Code plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "cedricziel": {
+      "source": {
+        "source": "github",
+        "repo": "cedricziel/claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "common@cedricziel": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ TrueNAS Manager - A Flutter application for managing TrueNAS servers on iOS and 
 
 ## Tooling Notes
 - `gtimeout` is used for adding timeouts to bash commands
+- `.claude/settings.json` enables the `common@cedricziel` Claude Code plugin
+  (from `cedricziel/claude-plugins`), which auto-formats edited files via
+  `dart format` on save
 
 ## Development Philosophy
 - We want to use best-practices like coding against interfaces, dependency injection etc whenever we can and it's our responsibility to gradually modernize the parts of the app we touch


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` registering the `cedricziel` marketplace (`cedricziel/claude-plugins`) and enabling `common@cedricziel`, which auto-formats edited files (`dart format` among others) via its `PostToolUse` hook.
- Note the new dependency in `CLAUDE.md`'s Tooling Notes.

Companion to [cedricziel/claude-plugins#1](https://github.com/cedricziel/claude-plugins/pull/1), which introduces the `common` plugin.

## Test plan
- [x] `.claude/settings.json` is valid JSON
- N/A — no application code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBHTZvD1iVTYzCx6JXU8Vd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project tooling configuration to support standardized development workflows.
  * Enabled automatic Dart code formatting when files are saved.

* **Documentation**
  * Added guidance describing the configured development tooling and formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->