### PR TITLE
fix: delete servers and Keychain passwords when clearing database

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:truehub/providers/tray_provider.dart';
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/authentication_session_service.dart';
 import 'package:truehub/services/secure_storage_service.dart';
+import 'package:truehub/services/unified_server_service.dart';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
@@ -240,6 +241,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
       // Clear the provider state first
       final serverProvider = context.read<ServerProvider>();
       serverProvider.clearSelectedServer();
+
+      // Delete every server through the repository abstraction so CloudKit
+      // records (Apple platforms) and Keychain passwords (all platforms) are
+      // actually removed, not just the local drift cache below.
+      final unifiedServerService = context.read<UnifiedServerService>();
+      final servers = await unifiedServerService.getAllServers();
+      for (final server in servers) {
+        await unifiedServerService.deleteServerConfig(server.id);
+      }
 
       // Completely recreate the database file to ensure fresh schema
       try {


### PR DESCRIPTION
## What was wrong

Settings > Clear Database told the user "This will permanently delete all servers and app data. This action cannot be undone," but `_clearDatabase` only ever deleted the local drift SQLite file. On iOS/macOS, server metadata actually lives in `CloudKitServerRepository` (per `server_repository_factory.dart`), so servers reappeared as soon as `ServerProvider.loadServersAndAutoSelect()` reloaded from CloudKit. Keychain passwords were never removed on any platform either, since the flow never called `UnifiedServerService.deleteServerConfig`.

## What changed

`_clearDatabase` now fetches all servers from `UnifiedServerService` and deletes each one through `deleteServerConfig` — which removes the repository record (CloudKit or SQLite, whichever is active) *and* the Keychain password — before the existing local drift file cleanup runs.

The diff is intentionally minimal and scoped only to this issue; two related findings in the same method (the disposed `AppDatabase` singleton reuse, and the success dialog's double `Navigator.pop()`) are being fixed separately in #107 and #108 to avoid merge conflicts.

## Testing

Flutter/Dart tooling (`flutter analyze`, `dart format`, `flutter test`) is not available in this environment, so this was verified by manual code reading only. CI (GitHub Actions, macos-latest) will run analyze, format-check, and the full test suite on this PR.

Closes #106

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_