### PR TITLE
fix: stop Clear Database success dialog from double-popping the router

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -286,10 +286,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             actions: [
               CupertinoDialogAction(
-                onPressed: () {
-                  Navigator.of(context).pop(); // Close success dialog
-                  Navigator.of(context).pop(); // Return to home screen
-                },
+                onPressed: () =>
+                    Navigator.of(context).pop(), // Close success dialog
                 child: const Text('OK'),
               ),
             ],


### PR DESCRIPTION
## What was wrong

The "Database Recreated" success dialog's OK action called `Navigator.of(context).pop()` twice. `showCupertinoDialog` defaults to `useRootNavigator: true`, so both pops target the root navigator: the first closes the dialog, and the second pops the Settings page underneath it. But Settings is never pushed onto the stack — it's a go_router shell destination reached via `context.go('/settings')` — so that second pop tries to remove the only page in the route stack, tripping go_router's "match list is empty" assertion (debug) or leaving a blank screen with an empty route configuration (release).

## What changed

Dropped the second `pop()` call so the OK action only closes the success dialog, leaving the user on the Settings screen (which reflects the freshly recreated database), matching the "suggested fix" in #108.

This is a minimal, single-line-scope change to just this one dialog action, to avoid conflicting with #106 and #107, which are being fixed concurrently in the same file/method by other PRs.

## Testing

Flutter/Dart tooling (`flutter analyze`, `dart format`, `flutter test`) is not available in this environment, so no local verification was possible. CI (GitHub Actions, macos-latest) will run `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` on this PR.

No new test was added: the issue doesn't explicitly ask for a regression test, and the existing `test/screens/settings_screen_test.dart` has a deliberate comment explaining why the full confirm→recreate path isn't exercised in tests (it reaches the real `AppDatabase.instance` singleton and `path_provider`, which would be flaky in that environment). The existing confirm/cancel dialog tests already cover the other branches of this method.

Closes #108

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_