### PR TITLE
fix: stop pinning AppProvider to a database instance closed by Clear Database

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (context) => AppProvider(
-            database: database,
+            databaseRef: () => AppDatabase.instance,
             serverService: unifiedServerService,
           ),
         ),

--- a/lib/providers/app_provider.dart
+++ b/lib/providers/app_provider.dart
@@ -12,7 +12,7 @@ import 'package:truehub/services/unified_server_service.dart';
 import 'package:truehub/providers/server_provider.dart';
 
 class AppProvider extends ChangeNotifier {
-  final AppDatabase _database;
+  final AppDatabase Function() _databaseRef;
   final UnifiedServerService _serverService;
   ApiClientInterface? _apiClient;
   String? _currentServerId;
@@ -24,11 +24,25 @@ class AppProvider extends ChangeNotifier {
   StreamSubscription<Map<String, AppResourceUsage>>? _appStatsSubscription;
   final Map<String, AppResourceUsage> _lastKnownResourceUsage = {};
 
+  /// [databaseRef] is looked up on every access instead of being captured
+  /// once, so callers that recreate the database (e.g. after a "clear
+  /// database" operation disposes [AppDatabase.instance]) are picked up
+  /// transparently instead of leaving this provider pinned to a closed
+  /// instance. [database] remains as a convenience for callers (mainly
+  /// tests) that already hold a fixed, never-disposed instance to inject;
+  /// prefer [databaseRef] for anything backed by the app-wide singleton.
   AppProvider({
-    required AppDatabase database,
+    AppDatabase Function()? databaseRef,
+    AppDatabase? database,
     required UnifiedServerService serverService,
-  }) : _database = database,
+  }) : assert(
+         databaseRef != null || database != null,
+         'AppProvider requires either databaseRef or database',
+       ),
+       _databaseRef = databaseRef ?? (() => database!),
        _serverService = serverService;
+
+  AppDatabase get _database => _databaseRef();
 
   List<AppConfig> get appConfigs => _appConfigs;
   List<String> get categories => _categories;
@@ -154,13 +168,15 @@ class AppProvider extends ChangeNotifier {
       _connectionError = null;
     } on ConnectionException catch (e) {
       _connectionError = e.error;
-      // Fall back to offline data if available
-      await _loadPersistedAppConfigs();
+      // Fall back to offline data if available. This fallback has its own
+      // try/catch so a failure here (e.g. a database that is unavailable)
+      // records a ConnectionError instead of escaping loadApps().
+      await _tryLoadPersistedAppConfigs();
     } catch (e) {
       // Handle unexpected errors
       _connectionError = ConnectionError.unknown(details: e.toString());
-      // Fall back to offline data if available
-      await _loadPersistedAppConfigs();
+      // Fall back to offline data if available. See note above.
+      await _tryLoadPersistedAppConfigs();
     } finally {
       _isLoading = false;
       notifyListeners();
@@ -254,6 +270,21 @@ class AppProvider extends ChangeNotifier {
 
     if (kDebugMode) {
       print('AppProvider: Loaded ${_appConfigs.length} persisted app configs');
+    }
+  }
+
+  /// Fallback wrapper around [_loadPersistedAppConfigs] used from the
+  /// catch blocks in [loadApps]. Swallows its own errors (recording a
+  /// ConnectionError instead) so a broken database doesn't let a failure
+  /// escape loadApps() while it is already handling one.
+  Future<void> _tryLoadPersistedAppConfigs() async {
+    try {
+      await _loadPersistedAppConfigs();
+    } catch (e) {
+      _connectionError = ConnectionError.unknown(details: e.toString());
+      if (kDebugMode) {
+        print('AppProvider: Failed to load persisted app configs: $e');
+      }
     }
   }
 


### PR DESCRIPTION
## What was wrong

`main.dart` resolved `AppDatabase.instance` once at startup and handed that fixed instance to `AppProvider`, which stored it for its lifetime. Settings screen's "Clear Database" action disposes that same singleton (`AppDatabase.disposeInstance()`), but `AppProvider` kept querying the now-closed instance afterwards. On top of that, `loadApps()`'s fallback to `_loadPersistedAppConfigs()` ran inside the same catch block already handling a failure, so a database error there could escape `loadApps()` entirely and break later app screens for the rest of the session.

## What changed

- `AppProvider` now takes an `AppDatabase Function() databaseRef` accessor that is re-resolved on every access instead of a captured instance, so a database recreated after "Clear Database" is picked up transparently. `main.dart` now passes `databaseRef: () => AppDatabase.instance`.
- A plain `AppDatabase database` parameter is still accepted for callers (mainly existing tests) that already inject a fixed, never-disposed instance, so no other call sites needed to change.
- `loadApps()`'s persisted-config fallback is now wrapped in its own try/catch (`_tryLoadPersistedAppConfigs`), so a failure there records a `ConnectionError` instead of throwing out of `loadApps()`.

## Testing

Flutter/Dart tooling is not available in the environment this change was made in, so `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` were not run locally. CI will run all three on this PR.

No new automated test was added: the issue's rationale for the DI change was general testability, not an explicit regression-test request, and reproducing this specific scenario would require constructing the production `AppDatabase.instance` singleton, which this repo's test suite deliberately avoids (see `test/flutter_test_config.dart`).

Closes #107

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_