### PR TITLE
fix: close cached API client when a server is deleted

### DIFF
--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -212,6 +212,10 @@ class ServerProvider extends ChangeNotifier {
       throw Exception('Failed to delete server configuration');
     }
 
+    // The server no longer exists, so its cached client (and any live
+    // websocket/keepalive timer it holds) must not survive the deletion.
+    await ApiClientManager.closeClient(id);
+
     if (_selectedServer?.id == id) {
       _selectedServer = null;
       _clearAuthState();

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -197,28 +197,38 @@ void main() {
       expect(serverProvider.selectedServer, isNull);
     });
 
-    test('should close the cached API client when a server is deleted', () async {
-      // Seed the mock manager with a cached client for this server, the way
-      // a real `getClient()` call from `selectServer` would. The mock's
-      // `getClient` does not itself register a client on a cache miss, so
-      // without this the `hasClient` assertion below would pass trivially
-      // regardless of whether `deleteServer` actually closes the client.
-      TestProviders.mockApiClientManager.addMockClient(
-        testServer.id,
-        FakeApiClient(),
-      );
-      await serverProvider.selectServer(testServer);
-      expect(ApiClientManager.hasClient(testServer.id), isTrue);
+    test(
+      'should close the cached API client when a server is deleted',
+      () async {
+        // Select the server first: `selectServer` unconditionally releases
+        // whatever client the *previous* selection held (see its "Release
+        // previous client if any" step), including when reselecting the
+        // already-selected server. Seeding the mock client before this call
+        // would have it wiped out by that release before the assertion below
+        // ever sees it.
+        await serverProvider.selectServer(testServer);
 
-      // Deleting the server must not leave a stale client (and its
-      // websocket/keepalive timer) behind for a server that no longer exists.
-      await serverProvider.deleteServer(testServer.id);
+        // Seed the mock manager with a cached client for this server, the way
+        // a real `getClient()` call from `selectServer` would. The mock's
+        // `getClient` does not itself register a client on a cache miss, so
+        // without this the `hasClient` assertion below would pass trivially
+        // regardless of whether `deleteServer` actually closes the client.
+        TestProviders.mockApiClientManager.addMockClient(
+          testServer.id,
+          FakeApiClient(),
+        );
+        expect(ApiClientManager.hasClient(testServer.id), isTrue);
 
-      expect(ApiClientManager.hasClient(testServer.id), isFalse);
+        // Deleting the server must not leave a stale client (and its
+        // websocket/keepalive timer) behind for a server that no longer exists.
+        await serverProvider.deleteServer(testServer.id);
 
-      // Restore the test server for other tests relying on setUp state.
-      await serverProvider.addServer(testServer, 'password');
-    });
+        expect(ApiClientManager.hasClient(testServer.id), isFalse);
+
+        // Restore the test server for other tests relying on setUp state.
+        await serverProvider.addServer(testServer, 'password');
+      },
+    );
 
     test('should update server and maintain consistency', () async {
       // Add another server

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:drift/native.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/server_provider.dart';
+import 'package:truehub/services/api_client_manager.dart';
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
 import '../helpers/test_providers.dart';
@@ -193,6 +194,20 @@ void main() {
 
       // Selected server should be null after deletion
       expect(serverProvider.selectedServer, isNull);
+    });
+
+    test('should close the cached API client when a server is deleted', () async {
+      // Select the server so it may pick up a cached client.
+      await serverProvider.selectServer(testServer);
+
+      // Deleting the server must not leave a stale client (and its
+      // websocket/keepalive timer) behind for a server that no longer exists.
+      await serverProvider.deleteServer(testServer.id);
+
+      expect(ApiClientManager.hasClient(testServer.id), isFalse);
+
+      // Restore the test server for other tests relying on setUp state.
+      await serverProvider.addServer(testServer, 'password');
     });
 
     test('should update server and maintain consistency', () async {

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:truehub/providers/server_provider.dart';
 import 'package:truehub/services/api_client_manager.dart';
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
+import '../helpers/fake_api_client.dart';
 import '../helpers/test_providers.dart';
 
 void main() {
@@ -197,8 +198,17 @@ void main() {
     });
 
     test('should close the cached API client when a server is deleted', () async {
-      // Select the server so it may pick up a cached client.
+      // Seed the mock manager with a cached client for this server, the way
+      // a real `getClient()` call from `selectServer` would. The mock's
+      // `getClient` does not itself register a client on a cache miss, so
+      // without this the `hasClient` assertion below would pass trivially
+      // regardless of whether `deleteServer` actually closes the client.
+      TestProviders.mockApiClientManager.addMockClient(
+        testServer.id,
+        FakeApiClient(),
+      );
       await serverProvider.selectServer(testServer);
+      expect(ApiClientManager.hasClient(testServer.id), isTrue);
 
       // Deleting the server must not leave a stale client (and its
       // websocket/keepalive timer) behind for a server that no longer exists.


### PR DESCRIPTION
## What was wrong

`ServerProvider.deleteServer` removed the server's stored config and cleared selection state, but unlike every other code path that stops using a server (`selectServer`, `clearSelectedServer`, `updateServer`'s non-selected branch, `dispose`), it never released the server's `ApiClientManager` entry. The deleted server's client — including its live websocket and keepalive timer — kept running for the rest of the app session, pushing connection updates for a server whose Keychain password had just been wiped.

## What changed

`deleteServer` now calls `await ApiClientManager.closeClient(id)` right after the repository delete succeeds, before touching selection state. `closeClient` is a no-op when no client is cached for that id, so this is safe regardless of whether the deleted server was ever selected/connected.

Added a regression test (`test/providers/server_provider_test.dart`) asserting `ApiClientManager.hasClient(id)` is `false` after `deleteServer`.

This change is intentionally scoped to only the `deleteServer` method to avoid conflicting with a separate, concurrent PR touching `_emitAuthStatus`/`dispose` in this same file (issue #104).

## Testing

Flutter/Dart tooling (flutter, dart, dart format) is not available in this sandbox, so `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` could not be run locally. CI on this PR will run all three.

Closes #109

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_