### PR TITLE
fix: unsubscribe from system stats synchronously on dispose

### DIFF
--- a/lib/screens/server_detail_screen.dart
+++ b/lib/screens/server_detail_screen.dart
@@ -27,6 +27,8 @@ class ServerDetailScreen extends StatefulWidget {
 }
 
 class _ServerDetailScreenState extends State<ServerDetailScreen> {
+  late final SystemStatsProvider _systemStatsProvider;
+
   @override
   void initState() {
     super.initState();
@@ -60,13 +62,19 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _systemStatsProvider = context.read<SystemStatsProvider>();
+  }
+
+  @override
   void dispose() {
-    // Unsubscribe from system stats when screen is disposed
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        context.read<SystemStatsProvider>().unsubscribeFromStats();
-      }
-    });
+    // Unsubscribe from system stats when screen is disposed. The provider
+    // was captured synchronously in didChangeDependencies(), so this runs
+    // immediately and doesn't need a frame boundary or a `mounted` check -
+    // by the time dispose() runs the element is already unmounted, which
+    // made a post-frame callback here dead code.
+    _systemStatsProvider.unsubscribeFromStats();
     super.dispose();
   }
 

--- a/lib/screens/server_detail_screen.dart
+++ b/lib/screens/server_detail_screen.dart
@@ -27,7 +27,7 @@ class ServerDetailScreen extends StatefulWidget {
 }
 
 class _ServerDetailScreenState extends State<ServerDetailScreen> {
-  late final SystemStatsProvider _systemStatsProvider;
+  SystemStatsProvider? _systemStatsProvider;
 
   @override
   void initState() {
@@ -64,7 +64,16 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _systemStatsProvider = context.read<SystemStatsProvider>();
+    // didChangeDependencies() runs after initState() and again any time an
+    // InheritedWidget this element depends on notifies - here that's the
+    // ModalRoute this screen builds against via
+    // ShellNavigationLeading.maybeBuild()'s `ModalRoute.of(context)`, which
+    // fires whenever a sub-route (Edit Server, Pools, Files, Health, ...)
+    // is pushed on top of or popped back to this screen. `??=` makes the
+    // capture idempotent across those repeat calls; assigning unconditionally
+    // to a `late final` field here would throw a LateInitializationError the
+    // first time the user navigated to any of this screen's sub-routes.
+    _systemStatsProvider ??= context.read<SystemStatsProvider>();
   }
 
   @override
@@ -74,7 +83,7 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
     // immediately and doesn't need a frame boundary or a `mounted` check -
     // by the time dispose() runs the element is already unmounted, which
     // made a post-frame callback here dead code.
-    _systemStatsProvider.unsubscribeFromStats();
+    _systemStatsProvider?.unsubscribeFromStats();
     super.dispose();
   }
 

--- a/test/screens/server_detail_screen_test.dart
+++ b/test/screens/server_detail_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/server_provider.dart';
+import 'package:truehub/providers/system_stats_provider.dart';
 import 'package:truehub/screens/server_detail_screen.dart';
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
@@ -231,6 +232,54 @@ void main() {
       expectNoLayoutOverflow(tester);
     },
   );
+
+  testWidgets(
+    'unsubscribes from system stats when the screen is disposed '
+    '(regression test for #102)',
+    (WidgetTester tester) async {
+      useCompactSurface(tester);
+
+      final systemStatsProvider = _RecordingSystemStatsProvider(
+        unifiedServerService,
+      );
+      addTearDown(systemStatsProvider.dispose);
+
+      await tester.pumpWidget(
+        provideAppProviders(
+          database: database,
+          service: unifiedServerService,
+          serverProvider: serverProvider,
+          systemStatsProvider: systemStatsProvider,
+          child: CupertinoApp(home: ServerDetailScreen(server: testServer)),
+        ),
+      );
+      await pumpUntilFound(tester, find.text('Storage Pools'));
+
+      expect(systemStatsProvider.unsubscribeCallCount, 0);
+
+      // Replacing the whole tree tears down ServerDetailScreen's State,
+      // running its dispose() - the same teardown a back navigation or tab
+      // switch triggers in the real app.
+      await tester.pumpWidget(const CupertinoApp(home: SizedBox.shrink()));
+
+      expect(systemStatsProvider.unsubscribeCallCount, 1);
+    },
+  );
+}
+
+/// A [SystemStatsProvider] that records how many times
+/// [unsubscribeFromStats] is called, so tests can assert the subscription
+/// is torn down on screen disposal without a live API client.
+class _RecordingSystemStatsProvider extends SystemStatsProvider {
+  _RecordingSystemStatsProvider(super.service);
+
+  int unsubscribeCallCount = 0;
+
+  @override
+  Future<void> unsubscribeFromStats() async {
+    unsubscribeCallCount++;
+    await super.unsubscribeFromStats();
+  }
 }
 
 /// An [AppProvider] whose [apps] and [favoriteApps] are seeded directly,

--- a/test/screens/server_detail_screen_test.dart
+++ b/test/screens/server_detail_screen_test.dart
@@ -233,84 +233,86 @@ void main() {
     },
   );
 
-  testWidgets(
-    'unsubscribes from system stats when the screen is disposed '
-    '(regression test for #102)',
-    (WidgetTester tester) async {
-      useCompactSurface(tester);
+  testWidgets('unsubscribes from system stats when the screen is disposed '
+      '(regression test for #102)', (WidgetTester tester) async {
+    useCompactSurface(tester);
 
-      final systemStatsProvider = _RecordingSystemStatsProvider(
-        unifiedServerService,
-      );
-      addTearDown(systemStatsProvider.dispose);
+    final systemStatsProvider = _RecordingSystemStatsProvider(
+      unifiedServerService,
+    );
+    addTearDown(systemStatsProvider.dispose);
 
-      await tester.pumpWidget(
-        provideAppProviders(
-          database: database,
-          service: unifiedServerService,
-          serverProvider: serverProvider,
-          systemStatsProvider: systemStatsProvider,
-          child: CupertinoApp(home: ServerDetailScreen(server: testServer)),
-        ),
-      );
-      await pumpUntilFound(tester, find.text('Storage Pools'));
+    await tester.pumpWidget(
+      provideAppProviders(
+        database: database,
+        service: unifiedServerService,
+        serverProvider: serverProvider,
+        systemStatsProvider: systemStatsProvider,
+        child: CupertinoApp(home: ServerDetailScreen(server: testServer)),
+      ),
+    );
+    await pumpUntilFound(tester, find.text('Storage Pools'));
 
-      expect(systemStatsProvider.unsubscribeCallCount, 0);
+    expect(systemStatsProvider.unsubscribeCallCount, 0);
 
-      // Replacing the whole tree tears down ServerDetailScreen's State,
-      // running its dispose() - the same teardown a back navigation or tab
-      // switch triggers in the real app.
-      await tester.pumpWidget(const CupertinoApp(home: SizedBox.shrink()));
+    // Replacing the whole tree tears down ServerDetailScreen's State,
+    // running its dispose() - the same teardown a back navigation or tab
+    // switch triggers in the real app.
+    await tester.pumpWidget(const CupertinoApp(home: SizedBox.shrink()));
 
-      expect(systemStatsProvider.unsubscribeCallCount, 1);
-    },
-  );
+    expect(systemStatsProvider.unsubscribeCallCount, 1);
+  });
 
-  testWidgets(
-    'survives a sub-route being pushed on top without crashing or '
-    'unsubscribing early (regression test for #102)',
-    (WidgetTester tester) async {
-      useCompactSurface(tester);
+  testWidgets('survives a sub-route being pushed on top without crashing or '
+      'unsubscribing early (regression test for #102)', (
+    WidgetTester tester,
+  ) async {
+    useCompactSurface(tester);
 
-      // ShellNavigationLeading.maybeBuild() calls `ModalRoute.of(context)`
-      // from ServerDetailScreen's own build context, so this screen's
-      // element depends on its ModalRoute. Pushing another route on top -
-      // exactly what happens when the user taps "Edit Server", "Pools",
-      // "Files" or "Health" - flips that route's `isCurrent` and re-runs
-      // didChangeDependencies() on the still-mounted ServerDetailScreen
-      // State, without disposing it.
-      final systemStatsProvider = _RecordingSystemStatsProvider(
-        unifiedServerService,
-      );
-      addTearDown(systemStatsProvider.dispose);
+    // ShellNavigationLeading.maybeBuild() calls `ModalRoute.of(context)`
+    // from ServerDetailScreen's own build context, so this screen's
+    // element depends on its ModalRoute. Pushing another route on top -
+    // exactly what happens when the user taps "Edit Server", "Pools",
+    // "Files" or "Health" - flips that route's `isCurrent` and re-runs
+    // didChangeDependencies() on the still-mounted ServerDetailScreen
+    // State, without disposing it.
+    final systemStatsProvider = _RecordingSystemStatsProvider(
+      unifiedServerService,
+    );
+    addTearDown(systemStatsProvider.dispose);
 
-      await tester.pumpWidget(
-        provideAppProviders(
-          database: database,
-          service: unifiedServerService,
-          serverProvider: serverProvider,
-          systemStatsProvider: systemStatsProvider,
-          child: CupertinoApp(home: ServerDetailScreen(server: testServer)),
-        ),
-      );
-      await pumpUntilFound(tester, find.text('Storage Pools'));
+    await tester.pumpWidget(
+      provideAppProviders(
+        database: database,
+        service: unifiedServerService,
+        serverProvider: serverProvider,
+        systemStatsProvider: systemStatsProvider,
+        child: CupertinoApp(home: ServerDetailScreen(server: testServer)),
+      ),
+    );
+    await pumpUntilFound(tester, find.text('Storage Pools'));
 
-      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
-      navigator.push(
-        CupertinoPageRoute<void>(builder: (_) => const SizedBox.shrink()),
-      );
-      await tester.pumpAndSettle();
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.push(
+      CupertinoPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+    );
+    // Not pumpAndSettle(): this screen can render an indefinite
+    // CupertinoActivityIndicator elsewhere (see pump_helpers.dart's module
+    // doc), so bound the pump to the Cupertino page-transition duration
+    // instead of waiting for every animation to stop.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
 
-      expect(tester.takeException(), isNull);
-      expect(systemStatsProvider.unsubscribeCallCount, 0);
+    expect(tester.takeException(), isNull);
+    expect(systemStatsProvider.unsubscribeCallCount, 0);
 
-      navigator.pop();
-      await tester.pumpAndSettle();
+    navigator.pop();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
 
-      expect(tester.takeException(), isNull);
-      expect(systemStatsProvider.unsubscribeCallCount, 0);
-    },
-  );
+    expect(tester.takeException(), isNull);
+    expect(systemStatsProvider.unsubscribeCallCount, 0);
+  });
 }
 
 /// A [SystemStatsProvider] that records how many times

--- a/test/screens/server_detail_screen_test.dart
+++ b/test/screens/server_detail_screen_test.dart
@@ -265,6 +265,52 @@ void main() {
       expect(systemStatsProvider.unsubscribeCallCount, 1);
     },
   );
+
+  testWidgets(
+    'survives a sub-route being pushed on top without crashing or '
+    'unsubscribing early (regression test for #102)',
+    (WidgetTester tester) async {
+      useCompactSurface(tester);
+
+      // ShellNavigationLeading.maybeBuild() calls `ModalRoute.of(context)`
+      // from ServerDetailScreen's own build context, so this screen's
+      // element depends on its ModalRoute. Pushing another route on top -
+      // exactly what happens when the user taps "Edit Server", "Pools",
+      // "Files" or "Health" - flips that route's `isCurrent` and re-runs
+      // didChangeDependencies() on the still-mounted ServerDetailScreen
+      // State, without disposing it.
+      final systemStatsProvider = _RecordingSystemStatsProvider(
+        unifiedServerService,
+      );
+      addTearDown(systemStatsProvider.dispose);
+
+      await tester.pumpWidget(
+        provideAppProviders(
+          database: database,
+          service: unifiedServerService,
+          serverProvider: serverProvider,
+          systemStatsProvider: systemStatsProvider,
+          child: CupertinoApp(home: ServerDetailScreen(server: testServer)),
+        ),
+      );
+      await pumpUntilFound(tester, find.text('Storage Pools'));
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.push(
+        CupertinoPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(systemStatsProvider.unsubscribeCallCount, 0);
+
+      navigator.pop();
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(systemStatsProvider.unsubscribeCallCount, 0);
+    },
+  );
 }
 
 /// A [SystemStatsProvider] that records how many times


### PR DESCRIPTION
## What was wrong

`ServerDetailScreen.dispose()` wrapped `unsubscribeFromStats()` in a post-frame callback guarded by `if (mounted)`. By the time that callback runs (the frame after dispose), the element has already been unmounted, so `mounted` is always `false` and the unsubscribe call is dead code. The websocket system-stats subscription set up in `initState` (and its per-tick `notifyListeners()`) stays alive for the rest of the app session on every visit to the screen, with no user-visible error.

## What changed

- `lib/screens/server_detail_screen.dart`: capture the `SystemStatsProvider` synchronously in `didChangeDependencies()` and call `unsubscribeFromStats()` directly from `dispose()`, removing the post-frame indirection and the now-incorrect `mounted` guard entirely.
- `test/screens/server_detail_screen_test.dart`: regression test using a recording `SystemStatsProvider` fake (following the existing `_FakePoolProvider`/`_FakeAppProvider` pattern and the `provideAppProviders` test helper) that asserts `unsubscribeFromStats()` is called exactly once when the screen's `State` is disposed.

## Verification

This container has no Flutter/Dart SDK available, so `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` could not be run locally. The change was verified by careful manual reading of the current file and matched to the existing code style. CI (GitHub Actions, macos-latest) will run analyze/format/tests against this PR.

Closes #102

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system-stat subscription cleanup when leaving a server detail screen.
  * Prevented subscriptions from being removed unexpectedly when navigating to and returning from a sub-screen.

* **Tests**
  * Added coverage to verify subscriptions remain active during sub-navigation and are properly removed when the screen is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->