### PR TITLE
fix: guard ServerProvider auth emit after dispose

### DIFF
--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -101,6 +101,7 @@ class ServerProvider extends ChangeNotifier {
   Future<void> _loadServers() async {
     try {
       _servers = await _serverService.getAllServers();
+      if (_disposed) return;
       notifyListeners();
     } catch (e) {
       if (kDebugMode) {
@@ -235,6 +236,7 @@ class ServerProvider extends ChangeNotifier {
     if (server != null) {
       await _authenticateAndConnect(server);
     }
+    if (_disposed) return;
     notifyListeners();
   }
 

--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -49,6 +49,7 @@ class ServerProvider extends ChangeNotifier {
   String? _userError;
 
   late StreamSubscription<List<models.NasServer>> _serversSubscription;
+  bool _disposed = false;
 
   ServerProvider(this._serverService) {
     _initializeProvider();
@@ -114,12 +115,15 @@ class ServerProvider extends ChangeNotifier {
   }
 
   Future<void> _autoSelectServer() async {
+    if (_disposed) return;
+
     if (_selectedServer != null) {
       return; // Don't auto-select if server already selected
     }
 
     // First check for default server
     final defaultServer = await _serverService.getDefaultServer();
+    if (_disposed) return;
     if (defaultServer != null) {
       await selectServer(defaultServer);
       return;
@@ -245,6 +249,7 @@ class ServerProvider extends ChangeNotifier {
   }
 
   void _emitAuthStatus() {
+    if (_disposed || _authController.isClosed) return;
     final status = AuthenticationStatus(
       state: _authState,
       error: _authError,
@@ -263,6 +268,8 @@ class ServerProvider extends ChangeNotifier {
       // Get credentials from unified server service
       final (serverWithCreds, password) = await _serverService
           .getServerWithPassword(server.id);
+
+      if (_disposed) return;
 
       if (serverWithCreds != null && password != null) {
         // Create server with credentials for API client
@@ -511,6 +518,7 @@ class ServerProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _disposed = true;
     if (_selectedServer != null) {
       // Note: We can't await in dispose, so we do a fire-and-forget cleanup
       ApiClientManager.releaseClient(_selectedServer!.id);

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -473,6 +473,35 @@ void main() {
       // Don't close the shared database here - it's managed by tearDown
     });
 
+    test(
+      'should not crash when disposed while auto-select/auth is in flight',
+      () async {
+        // ServerProvider's constructor starts a fire-and-forget auto-select
+        // chain (see _initializeProvider) that addServer() does not await.
+        // Disposing immediately after addServer(), before that chain settles,
+        // used to throw "Cannot add new events after calling close" from
+        // _emitAuthStatus once the dangling continuation resumed. Regression
+        // coverage for #104.
+        final testProvider = await TestProviders.createServerProvider(
+          database: database,
+        );
+        final raceServer = NasServer.create(
+          name: 'Race Server',
+          host: '192.168.1.101',
+          username: 'admin',
+          password: 'password',
+        );
+
+        await testProvider.addServer(raceServer, 'password');
+        testProvider.dispose();
+
+        // Give the dangling auto-select/authenticate continuation a chance
+        // to resume and reach _emitAuthStatus - it must no-op instead of
+        // throwing.
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      },
+    );
+
     test('should handle edge cases in auto-selection', () async {
       // Test auto-selection with clean provider state
       // Clear the existing servers first to test the edge case


### PR DESCRIPTION
## What was wrong

`ServerProvider`'s constructor kicks off a fire-and-forget auto-select/authenticate chain (`_initializeProvider` → `_autoSelectServer` → `selectServer` → `_authenticateAndConnect`) that callers like `addServer()` never await. If the provider is disposed while that chain is still in flight, the resumed continuation calls `_emitAuthStatus()`, which adds to the already-closed `_authController` and throws `Bad state: Cannot add new events after calling close`. Because it depends on timing, this shows up as an intermittent crash in tests with a tight `setUp`/`tearDown`.

## What changed

- Added a `_disposed` flag, set in `dispose()`.
- `_emitAuthStatus()` now returns early if the provider is disposed or `_authController` is already closed.
- `_autoSelectServer()` and `_authenticateAndConnect()` check `_disposed` at their resume points (after each `await`) and bail out instead of continuing to mutate state or emit on a disposed provider.
- Added a regression test in `test/providers/server_provider_test.dart` that adds a server and disposes the provider immediately afterward (without draining the auto-select chain), asserting the dangling continuation no longer throws.

This is scoped to the dispose-guard fix only (part 1 of the issue's suggested fix); the optional "await settle point" stretch goal was left out to keep the change minimal, since issue #109 is being fixed concurrently in a different method (`deleteServer`) of this same file.

## Verification

Flutter/Dart tooling is not available in this environment, so I was not able to run `flutter analyze`, `dart format --set-exit-if-changed .`, or `flutter test` locally. CI (GitHub Actions, macos-latest) will run all three on this PR.

Closes #104


---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_