### PR TITLE
fix: correct keychain mock argument cast and run package tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
           --no-pub \
           --coverage
 
+    - name: Run truenas_native_plugins package tests
+      working-directory: packages/truenas_native_plugins
+      run: flutter test --reporter=expanded --timeout=30s
+
     - name: Enforce coverage floor
       run: dart run tool/check_coverage.dart
 

--- a/packages/truenas_native_plugins/lib/src/test_utils/test_helpers.dart
+++ b/packages/truenas_native_plugins/lib/src/test_utils/test_helpers.dart
@@ -33,7 +33,7 @@ class TruenasPluginTestHelpers {
       final responses = keychainResponses ?? _defaultKeychainResponses;
 
       if (methodCall.method == 'getPassword') {
-        final args = methodCall.arguments as Map<String, dynamic>;
+        final args = (methodCall.arguments as Map).cast<String, dynamic>();
         final serverId = args['account'] as String;
         return responses['passwords']?[serverId];
       }


### PR DESCRIPTION
## What was wrong

`TruenasPluginTestHelpers.setupMethodChannelMocks`'s keychain mock handler cast `methodCall.arguments` directly `as Map<String, dynamic>`, but Flutter's `StandardMessageCodec` decodes method-call arguments as `Map<Object?, Object?>`. Every `getPassword` call that carried arguments threw a `TypeError` inside the mock handler (surfaced to the caller as a `PlatformException`), which made `packages/truenas_native_plugins/test/test_helpers_test.dart`'s "should support custom responses" test red. That package's suite was also never run in CI, since `.github/workflows/ci.yml` only runs `flutter test` at the repository root, so the failure went unnoticed.

## What changed

- `packages/truenas_native_plugins/lib/src/test_utils/test_helpers.dart`: decode the arguments defensively via `(methodCall.arguments as Map).cast<String, dynamic>()` instead of an unsafe direct cast.
- `.github/workflows/ci.yml`: added a `flutter test` step with `working-directory: packages/truenas_native_plugins` after the root test step, so this package's suite runs on every PR and can't rot silently again.

No new test was added — the existing "should support custom responses" test in `packages/truenas_native_plugins/test/test_helpers_test.dart` already exercises the buggy `getPassword` code path and turns green with this fix.

## Verification

Flutter/Dart tooling is not available in this environment, so `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` were not run locally. CI will run all three on this PR.

Closes #105


---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_