### PR TITLE
fix: stop CompactNavigation double-counting the bottom safe-area inset

### DIFF
--- a/lib/navigation/compact_navigation.dart
+++ b/lib/navigation/compact_navigation.dart
@@ -26,7 +26,13 @@ class CompactNavigation extends StatelessWidget {
     return CupertinoPageScaffold(
       child: Column(
         children: [
-          Expanded(child: child),
+          Expanded(
+            child: MediaQuery.removePadding(
+              context: context,
+              removeBottom: true,
+              child: child,
+            ),
+          ),
           CompactDestinationBar(
             selectedIndex: selectedIndex,
             onDestinationSelected: onDestinationSelected,

--- a/test/navigation/compact_navigation_test.dart
+++ b/test/navigation/compact_navigation_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:truehub/navigation/compact_navigation.dart';

--- a/test/navigation/compact_navigation_test.dart
+++ b/test/navigation/compact_navigation_test.dart
@@ -1,0 +1,60 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/navigation/compact_navigation.dart';
+
+/// Regression coverage for issue #112: `CompactNavigation` used to stack the
+/// routed screen above `CompactDestinationBar` with a bare `Expanded`, so the
+/// routed `child` still saw the full bottom `MediaQuery` padding even though
+/// the tab bar's `CupertinoTabBar` already reserves that inset for itself.
+/// Any routed screen wrapping its body in `SafeArea` then reserved the same
+/// inset a second time, leaving a blank strip above the tab bar.
+///
+/// `test/helpers/test_surfaces.dart` deliberately renders at zero view
+/// padding, so this test stubs `tester.view.padding` / `viewPadding` with a
+/// non-zero bottom inset directly rather than using that helper.
+void main() {
+  testWidgets(
+    'removes the bottom padding from the routed child, leaving the tab bar '
+    'as the sole consumer of the bottom safe-area inset',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 3.0;
+      tester.view.padding = const FakeViewPadding(bottom: 34);
+      tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+      addTearDown(tester.view.reset);
+
+      double? childBottomPadding;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CompactNavigation(
+            selectedIndex: 0,
+            onDestinationSelected: (_) {},
+            child: Builder(
+              builder: (context) {
+                childBottomPadding = MediaQuery.paddingOf(context).bottom;
+                return const SizedBox.expand();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        childBottomPadding,
+        0,
+        reason:
+            'the routed child must not see the bottom safe-area inset a '
+            'second time - CupertinoTabBar in CompactDestinationBar already '
+            'consumes it',
+      );
+
+      // The tab bar itself sits outside the removePadding scope (it is a
+      // sibling of the wrapped child, not inside it), so it is still present
+      // and unaffected - only the routed child's view of the inset changes.
+      expect(find.byType(CupertinoTabBar), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## What was wrong

`CompactNavigation` (`lib/navigation/compact_navigation.dart`) stacked the routed screen above `CompactDestinationBar` with a bare `Expanded`, so the routed `child` still saw the full bottom `MediaQuery` padding even though `CompactDestinationBar`'s `CupertinoTabBar` already consumes that inset for itself (it inflates its own height by `MediaQuery.viewPaddingOf(context).bottom`). Routed screens that wrap their body in `SafeArea` (most of them do — `HomeScreen`, `SettingsScreen`, `ServerDetailScreen`, etc.) then reserved that same inset a second time at their own bottom edge, leaving a blank strip between the screen's content and the tab bar.

## What changed

Wraps the routed `child` in `MediaQuery.removePadding(context: context, removeBottom: true, child: child)` before handing it to `Expanded`, so the bottom safe-area inset is zeroed for the routed subtree only — the sibling `CompactDestinationBar`/`CupertinoTabBar` is unaffected and still reserves the real inset. This mirrors how Flutter's own `CupertinoTabScaffold` avoids the same double-count.

Added a regression test at `test/navigation/compact_navigation_test.dart` that stubs `tester.view.padding`/`viewPadding` with a non-zero bottom inset (`test/helpers/test_surfaces.dart` deliberately uses zero padding, so that helper isn't used here) and asserts the routed child no longer sees the bottom padding.

## Testing

Flutter/Dart tooling was not available in the environment this fix was written in, so `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` were not run locally — CI will run all three on this PR.

Closes #112

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDSWh33keGkVapcGRPRPaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed excess bottom spacing in compact navigation content when the device’s bottom safe-area inset is already handled by the tab bar.
  * Preserved the tab bar layout while ensuring routed content displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->