### PR TITLE
feat: add a Jobs view, nav bar job indicator, and a segmented memory bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/dataset_provider.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:truehub/providers/tray_provider.dart';
 import 'package:truehub/navigation/app_router.dart';
@@ -52,6 +53,9 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (context) => SystemStatsProvider(unifiedServerService),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => JobsProvider(unifiedServerService),
         ),
         ChangeNotifierProvider(create: (context) => TrayProvider()),
       ],

--- a/lib/models/job.dart
+++ b/lib/models/job.dart
@@ -1,0 +1,186 @@
+import 'package:equatable/equatable.dart';
+
+/// Mirrors the `state` field of a TrueNAS `core.get_jobs` job record.
+enum JobState { waiting, running, success, failed, aborted, held, unknown }
+
+JobState _parseJobState(String? value) {
+  switch (value) {
+    case 'WAITING':
+      return JobState.waiting;
+    case 'RUNNING':
+      return JobState.running;
+    case 'SUCCESS':
+      return JobState.success;
+    case 'FAILED':
+      return JobState.failed;
+    case 'ABORTED':
+      return JobState.aborted;
+    case 'HELD':
+      return JobState.held;
+    default:
+      return JobState.unknown;
+  }
+}
+
+String _jobStateToJson(JobState state) {
+  switch (state) {
+    case JobState.waiting:
+      return 'WAITING';
+    case JobState.running:
+      return 'RUNNING';
+    case JobState.success:
+      return 'SUCCESS';
+    case JobState.failed:
+      return 'FAILED';
+    case JobState.aborted:
+      return 'ABORTED';
+    case JobState.held:
+      return 'HELD';
+    case JobState.unknown:
+      return 'UNKNOWN';
+  }
+}
+
+/// TrueNAS encodes `datetime` fields as `{"$date": <epoch milliseconds>}`.
+/// Accepts that shape defensively, plus a raw epoch-millisecond number or an
+/// ISO 8601 string, since the exact wire shape depends on the middleware
+/// version talking to the client.
+DateTime? _parseTrueNasDateTime(dynamic value) {
+  if (value == null) return null;
+  if (value is Map) {
+    final millis = value[r'$date'];
+    if (millis is num) {
+      return DateTime.fromMillisecondsSinceEpoch(millis.toInt());
+    }
+    return null;
+  }
+  if (value is num) {
+    return DateTime.fromMillisecondsSinceEpoch(value.toInt());
+  }
+  if (value is String) {
+    return DateTime.tryParse(value);
+  }
+  return null;
+}
+
+dynamic _dateTimeToJson(DateTime? value) {
+  if (value == null) return null;
+  return {r'$date': value.millisecondsSinceEpoch};
+}
+
+/// The `progress` field of a TrueNAS job: percent complete plus an optional
+/// human-readable description of the current step.
+class JobProgress extends Equatable {
+  final double percent;
+  final String? description;
+
+  const JobProgress({required this.percent, this.description});
+
+  factory JobProgress.fromJson(Map<String, dynamic>? json) {
+    if (json == null) return const JobProgress(percent: 0);
+    return JobProgress(
+      percent: (json['percent'] as num?)?.toDouble() ?? 0,
+      description: json['description'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'percent': percent,
+    'description': description,
+  };
+
+  @override
+  List<Object?> get props => [percent, description];
+}
+
+/// A TrueNAS job as returned by `core.get_jobs` / pushed through a
+/// `core.get_jobs` collection_update subscription.
+class Job extends Equatable {
+  final int id;
+  final String method;
+  final List<dynamic> arguments;
+  final String? description;
+  final JobProgress progress;
+  final JobState state;
+  final DateTime? timeStarted;
+  final DateTime? timeFinished;
+  final String? error;
+  final String? logsExcerpt;
+  final bool abortable;
+
+  const Job({
+    required this.id,
+    required this.method,
+    required this.arguments,
+    this.description,
+    required this.progress,
+    required this.state,
+    this.timeStarted,
+    this.timeFinished,
+    this.error,
+    this.logsExcerpt,
+    this.abortable = false,
+  });
+
+  factory Job.fromJson(Map<String, dynamic> json) {
+    return Job(
+      id: json['id'] as int,
+      method: json['method'] as String? ?? '',
+      arguments: (json['arguments'] as List<dynamic>?) ?? const [],
+      description: json['description'] as String?,
+      progress: JobProgress.fromJson(json['progress'] as Map<String, dynamic>?),
+      state: _parseJobState(json['state'] as String?),
+      timeStarted: _parseTrueNasDateTime(json['time_started']),
+      timeFinished: _parseTrueNasDateTime(json['time_finished']),
+      error: json['error'] as String?,
+      logsExcerpt: json['logs_excerpt'] as String?,
+      abortable: json['abortable'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'method': method,
+    'arguments': arguments,
+    'description': description,
+    'progress': progress.toJson(),
+    'state': _jobStateToJson(state),
+    'time_started': _dateTimeToJson(timeStarted),
+    'time_finished': _dateTimeToJson(timeFinished),
+    'error': error,
+    'logs_excerpt': logsExcerpt,
+    'abortable': abortable,
+  };
+
+  bool get isWaiting => state == JobState.waiting || state == JobState.held;
+  bool get isRunning => state == JobState.running;
+  bool get isFinished =>
+      state == JobState.success ||
+      state == JobState.failed ||
+      state == JobState.aborted;
+  bool get isFailed => state == JobState.failed;
+
+  /// Time elapsed since the job started, through now if it hasn't finished
+  /// yet. `null` if the job hasn't started (still queued).
+  Duration? get elapsed {
+    final started = timeStarted;
+    if (started == null) return null;
+    final end = timeFinished ?? DateTime.now();
+    return end.difference(started);
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    method,
+    arguments,
+    description,
+    progress,
+    state,
+    timeStarted,
+    timeFinished,
+    error,
+    logsExcerpt,
+    abortable,
+  ];
+}

--- a/lib/models/system_stats.dart
+++ b/lib/models/system_stats.dart
@@ -183,13 +183,12 @@ class MemoryStats extends Equatable {
   /// [physicalMemoryAvailable] alongside memory that is genuinely free - this
   /// is the "genuinely free" remainder once the ARC is split out.
   int get freeMemory =>
-      (physicalMemoryAvailable - arcSize).clamp(0, physicalMemoryTotal);
+      (physicalMemoryAvailable - arcSize).clamp(0, physicalMemoryTotal).toInt();
 
   /// Memory held by apps and services: everything not currently available.
-  int get appsMemory => (physicalMemoryTotal - physicalMemoryAvailable).clamp(
-    0,
-    physicalMemoryTotal,
-  );
+  int get appsMemory => (physicalMemoryTotal - physicalMemoryAvailable)
+      .clamp(0, physicalMemoryTotal)
+      .toInt();
 
   double get freeMemoryPercent {
     if (physicalMemoryTotal == 0) return 0.0;

--- a/lib/models/system_stats.dart
+++ b/lib/models/system_stats.dart
@@ -178,6 +178,29 @@ class MemoryStats extends Equatable {
     return (arcSize / physicalMemoryTotal) * 100;
   }
 
+  /// Memory neither held by apps/services nor cached in the ZFS ARC. TrueNAS
+  /// reports the ARC as reclaimable, i.e. included in
+  /// [physicalMemoryAvailable] alongside memory that is genuinely free - this
+  /// is the "genuinely free" remainder once the ARC is split out.
+  int get freeMemory =>
+      (physicalMemoryAvailable - arcSize).clamp(0, physicalMemoryTotal);
+
+  /// Memory held by apps and services: everything not currently available.
+  int get appsMemory => (physicalMemoryTotal - physicalMemoryAvailable).clamp(
+    0,
+    physicalMemoryTotal,
+  );
+
+  double get freeMemoryPercent {
+    if (physicalMemoryTotal == 0) return 0.0;
+    return (freeMemory / physicalMemoryTotal) * 100;
+  }
+
+  double get appsMemoryPercent {
+    if (physicalMemoryTotal == 0) return 0.0;
+    return (appsMemory / physicalMemoryTotal) * 100;
+  }
+
   @override
   List<Object?> get props => [
     arcSize,

--- a/lib/navigation/app_router.dart
+++ b/lib/navigation/app_router.dart
@@ -10,6 +10,7 @@ import 'package:truehub/screens/server_pools_screen.dart';
 import 'package:truehub/screens/server_apps_screen.dart';
 import 'package:truehub/screens/server_files_screen.dart';
 import 'package:truehub/screens/server_health_screen.dart';
+import 'package:truehub/screens/server_jobs_screen.dart';
 import 'package:truehub/navigation/adaptive_navigation_scaffold.dart';
 import 'package:truehub/navigation/server_route_host.dart';
 import 'package:truehub/models/nas_server.dart';
@@ -125,6 +126,14 @@ GoRouter createAppRouter({String initialLocation = '/servers'}) => GoRouter(
               pageBuilder: (context, state) => _serverPage(
                 state,
                 (server) => ServerHealthScreen(server: server),
+              ),
+            ),
+            GoRoute(
+              path: 'jobs',
+              name: 'server-jobs',
+              pageBuilder: (context, state) => _serverPage(
+                state,
+                (server) => ServerJobsScreen(server: server),
               ),
             ),
           ],

--- a/lib/providers/jobs_provider.dart
+++ b/lib/providers/jobs_provider.dart
@@ -64,6 +64,11 @@ class JobsProvider extends ChangeNotifier {
       await ApiClientManager.releaseClient(_currentServerId!);
     }
 
+    // Cleared up front so a missing-credentials or getClient() failure below
+    // leaves this provider clientless rather than still pointed at the
+    // previous server - subscribeToJobs/abortJob/rerunJob must never act on
+    // the wrong server's jobs.
+    _apiClient = null;
     _currentServerId = server.id;
 
     try {

--- a/lib/providers/jobs_provider.dart
+++ b/lib/providers/jobs_provider.dart
@@ -1,0 +1,279 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:truehub/models/job.dart';
+import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/providers/server_provider.dart';
+import 'package:truehub/services/api_client_interface.dart';
+import 'package:truehub/services/api_client_manager.dart';
+import 'package:truehub/services/unified_server_service.dart';
+
+/// How long a failed job keeps the nav bar's job indicator in its
+/// "needs attention" state after it finished.
+const kJobFailureAttentionWindow = Duration(hours: 24);
+
+class JobsProvider extends ChangeNotifier {
+  final UnifiedServerService _serverService;
+  ApiClientInterface? _apiClient;
+  String? _currentServerId;
+  List<Job> _jobs = [];
+  String? _error;
+  bool _isLoading = false;
+  bool _isSubscribed = false;
+  StreamSubscription<List<Job>>? _jobsSubscription;
+
+  JobsProvider(this._serverService);
+
+  List<Job> get jobs => _jobs;
+  String? get error => _error;
+  bool get isLoading => _isLoading;
+  bool get isSubscribed => _isSubscribed;
+  bool get hasData => _jobs.isNotEmpty;
+
+  List<Job> get runningJobs => _jobs.where((job) => job.isRunning).toList();
+  List<Job> get waitingJobs => _jobs.where((job) => job.isWaiting).toList();
+  List<Job> get historyJobs => _jobs.where((job) => job.isFinished).toList()
+    ..sort(
+      (a, b) => (b.timeFinished ?? DateTime.fromMillisecondsSinceEpoch(0))
+          .compareTo(a.timeFinished ?? DateTime.fromMillisecondsSinceEpoch(0)),
+    );
+
+  int get runningCount => runningJobs.length;
+  int get waitingCount => waitingJobs.length;
+
+  /// Jobs that failed within [kJobFailureAttentionWindow].
+  List<Job> get recentFailures => historyJobs
+      .where(
+        (job) =>
+            job.isFailed &&
+            job.timeFinished != null &&
+            DateTime.now().difference(job.timeFinished!) <
+                kJobFailureAttentionWindow,
+      )
+      .toList();
+
+  /// Whether the nav bar's job indicator should show the "needs attention"
+  /// state: nothing running right now, but something failed recently.
+  bool get needsAttention => runningCount == 0 && recentFailures.isNotEmpty;
+
+  Future<void> setApiClient(NasServer server) async {
+    if (_apiClient != null) {
+      await unsubscribeFromJobs();
+    }
+
+    if (_currentServerId != null) {
+      await ApiClientManager.releaseClient(_currentServerId!);
+    }
+
+    _currentServerId = server.id;
+
+    try {
+      final serverWithCredentials = await ServerProvider.loadServerCredentials(
+        server,
+        _serverService,
+      );
+
+      if (serverWithCredentials != null) {
+        _apiClient = await ApiClientManager.getClient(serverWithCredentials);
+      } else {
+        if (kDebugMode) {
+          print(
+            'JobsProvider: No credentials available for server ${server.id}',
+          );
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('JobsProvider: Failed to get API client: $e');
+      }
+    }
+  }
+
+  Future<void> subscribeToJobs() async {
+    if (_apiClient == null) {
+      _setError('No API client configured');
+      return;
+    }
+
+    if (_isSubscribed) {
+      if (kDebugMode) {
+        print('JobsProvider: Already subscribed to jobs');
+      }
+      return;
+    }
+
+    try {
+      _setLoading(true);
+      _clearError();
+
+      final initial = await _apiClient!.getJobs();
+      _jobs = initial;
+      notifyListeners();
+
+      await _apiClient!.subscribeToJobs();
+
+      _jobsSubscription = _apiClient!.jobsStream.listen(
+        _onJobsReceived,
+        onError: _onJobsError,
+        onDone: _onJobsStreamDone,
+      );
+
+      _isSubscribed = true;
+      if (kDebugMode) {
+        print('JobsProvider: Successfully subscribed to jobs stream');
+      }
+    } catch (e) {
+      _setError('Failed to subscribe to jobs: ${e.toString()}');
+      if (kDebugMode) {
+        print('JobsProvider: Subscription error: $e');
+      }
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  Future<void> unsubscribeFromJobs() async {
+    if (!_isSubscribed) {
+      return;
+    }
+
+    try {
+      await _jobsSubscription?.cancel();
+      _jobsSubscription = null;
+
+      if (_apiClient != null) {
+        await _apiClient!.unsubscribeFromJobs();
+      }
+
+      _isSubscribed = false;
+      _jobs = [];
+      _clearError();
+
+      if (kDebugMode) {
+        print('JobsProvider: Successfully unsubscribed from jobs');
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('JobsProvider: Error during unsubscription: $e');
+      }
+    }
+
+    notifyListeners();
+  }
+
+  /// Re-fetches the current job list without touching the live subscription;
+  /// starts one if there isn't one yet. Used for a pull-to-refresh / manual
+  /// reload affordance since job updates otherwise arrive push-only.
+  Future<void> refreshJobs() async {
+    if (_apiClient == null) {
+      _setError('No API client configured');
+      return;
+    }
+
+    if (!_isSubscribed) {
+      await subscribeToJobs();
+      return;
+    }
+
+    try {
+      _clearError();
+      _jobs = await _apiClient!.getJobs();
+      notifyListeners();
+    } catch (e) {
+      _setError('Failed to refresh jobs: ${e.toString()}');
+    }
+  }
+
+  Future<bool> abortJob(int jobId) async {
+    if (_apiClient == null) {
+      _setError('No API client configured');
+      return false;
+    }
+
+    try {
+      await _apiClient!.abortJob(jobId);
+      return true;
+    } catch (e) {
+      _setError('Failed to cancel job: ${e.toString()}');
+      return false;
+    }
+  }
+
+  Future<bool> rerunJob(Job job) async {
+    if (_apiClient == null) {
+      _setError('No API client configured');
+      return false;
+    }
+
+    try {
+      await _apiClient!.rerunJob(job);
+      return true;
+    } catch (e) {
+      _setError('Failed to retry job: ${e.toString()}');
+      return false;
+    }
+  }
+
+  void _onJobsReceived(List<Job> jobs) {
+    _jobs = jobs;
+    _clearError();
+    _setLoading(false);
+    notifyListeners();
+  }
+
+  void _onJobsError(dynamic error) {
+    _setError('Jobs stream error: ${error.toString()}');
+    _setLoading(false);
+    if (kDebugMode) {
+      print('JobsProvider: Stream error: $error');
+    }
+  }
+
+  void _onJobsStreamDone() {
+    _isSubscribed = false;
+    _setLoading(false);
+    if (kDebugMode) {
+      print('JobsProvider: Jobs stream done');
+    }
+    notifyListeners();
+  }
+
+  void _setLoading(bool loading) {
+    if (_isLoading != loading) {
+      _isLoading = loading;
+      notifyListeners();
+    }
+  }
+
+  void _setError(String error) {
+    _error = error;
+    _setLoading(false);
+    notifyListeners();
+  }
+
+  void _clearError() {
+    if (_error != null) {
+      _error = null;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (kDebugMode) {
+      print('JobsProvider: Disposing');
+    }
+    // Can't await in dispose(); fire-and-forget cleanup, same pattern as
+    // SystemStatsProvider.dispose().
+    _jobsSubscription?.cancel();
+    _jobsSubscription = null;
+    if (_apiClient != null) {
+      _apiClient!.unsubscribeFromJobs().catchError((_) {});
+    }
+    _isSubscribed = false;
+
+    if (_currentServerId != null) {
+      ApiClientManager.releaseClient(_currentServerId!);
+    }
+    super.dispose();
+  }
+}

--- a/lib/screens/pool_detail_screen.dart
+++ b/lib/screens/pool_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/dataset_provider.dart';
 import 'package:truehub/screens/dataset_detail_screen.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class PoolDetailScreen extends StatefulWidget {
   final NasServer server;
@@ -39,6 +40,7 @@ class _PoolDetailScreenState extends State<PoolDetailScreen> {
           child: const Text('Back'),
           onPressed: () => Navigator.pop(context),
         ),
+        trailing: JobsBellButton(server: widget.server),
       ),
       child: SafeArea(
         child: CustomScrollView(

--- a/lib/screens/server_apps_screen.dart
+++ b/lib/screens/server_apps_screen.dart
@@ -4,6 +4,7 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/models/app.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/widgets/app_card_widget.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class ServerAppsScreen extends StatefulWidget {
   final NasServer server;
@@ -47,12 +48,18 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
           child: const Icon(CupertinoIcons.back),
           onPressed: () => Navigator.pop(context),
         ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          child: const Icon(CupertinoIcons.refresh),
-          onPressed: () {
-            context.read<AppProvider>().refreshApps();
-          },
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            JobsBellButton(server: widget.server),
+            CupertinoButton(
+              padding: EdgeInsets.zero,
+              child: const Icon(CupertinoIcons.refresh),
+              onPressed: () {
+                context.read<AppProvider>().refreshApps();
+              },
+            ),
+          ],
         ),
       ),
       child: SafeArea(

--- a/lib/screens/server_detail_screen.dart
+++ b/lib/screens/server_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:truehub/providers/server_provider.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/widgets/system_stats_widget.dart';
 import 'package:truehub/widgets/authentication_state_widget.dart';
 import 'package:truehub/widgets/action_button_widget.dart';
@@ -15,6 +16,7 @@ import 'package:truehub/widgets/app_card_widget.dart';
 import 'package:truehub/widgets/error_state_widget.dart';
 import 'package:truehub/widgets/empty_state_widget.dart';
 import 'package:truehub/widgets/connection_status_widget.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
 import 'package:truehub/widgets/section_header.dart';
 
 class ServerDetailScreen extends StatefulWidget {
@@ -28,6 +30,7 @@ class ServerDetailScreen extends StatefulWidget {
 
 class _ServerDetailScreenState extends State<ServerDetailScreen> {
   SystemStatsProvider? _systemStatsProvider;
+  JobsProvider? _jobsProvider;
 
   @override
   void initState() {
@@ -37,6 +40,7 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
       final poolProvider = context.read<PoolProvider>();
       final appProvider = context.read<AppProvider>();
       final systemStatsProvider = context.read<SystemStatsProvider>();
+      final jobsProvider = context.read<JobsProvider>();
 
       // Check if this server is already selected and authenticated
       if (serverProvider.selectedServer?.id != widget.server.id) {
@@ -57,6 +61,12 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
 
         await systemStatsProvider.setApiClient(widget.server);
         await systemStatsProvider.subscribeToStats();
+
+        // Subscribed here (rather than in ServerJobsScreen) so the nav bar
+        // bell keeps reflecting job state on every screen pushed on top of
+        // this one, not just while the Jobs screen itself is open.
+        await jobsProvider.setApiClient(widget.server);
+        await jobsProvider.subscribeToJobs();
       }
     });
   }
@@ -74,16 +84,18 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
     // to a `late final` field here would throw a LateInitializationError the
     // first time the user navigated to any of this screen's sub-routes.
     _systemStatsProvider ??= context.read<SystemStatsProvider>();
+    _jobsProvider ??= context.read<JobsProvider>();
   }
 
   @override
   void dispose() {
-    // Unsubscribe from system stats when screen is disposed. The provider
-    // was captured synchronously in didChangeDependencies(), so this runs
-    // immediately and doesn't need a frame boundary or a `mounted` check -
-    // by the time dispose() runs the element is already unmounted, which
-    // made a post-frame callback here dead code.
+    // Unsubscribe from system stats and jobs when screen is disposed. The
+    // providers were captured synchronously in didChangeDependencies(), so
+    // this runs immediately and doesn't need a frame boundary or a `mounted`
+    // check - by the time dispose() runs the element is already unmounted,
+    // which made a post-frame callback here dead code.
     _systemStatsProvider?.unsubscribeFromStats();
+    _jobsProvider?.unsubscribeFromJobs();
     super.dispose();
   }
 
@@ -121,33 +133,39 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
                 ),
               ],
             ),
-            trailing: CupertinoButton(
-              padding: EdgeInsets.zero,
-              child: const Icon(CupertinoIcons.ellipsis),
-              onPressed: () {
-                showCupertinoModalPopup(
-                  context: context,
-                  builder: (context) => CupertinoActionSheet(
-                    actions: [
-                      CupertinoActionSheetAction(
-                        child: const Text('Edit Server'),
-                        onPressed: () async {
-                          Navigator.pop(context);
-                          context.push(
-                            '/server/${currentServer.id}/edit',
-                            extra: currentServer,
-                          );
-                        },
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                JobsBellButton(server: currentServer),
+                CupertinoButton(
+                  padding: EdgeInsets.zero,
+                  child: const Icon(CupertinoIcons.ellipsis),
+                  onPressed: () {
+                    showCupertinoModalPopup(
+                      context: context,
+                      builder: (context) => CupertinoActionSheet(
+                        actions: [
+                          CupertinoActionSheetAction(
+                            child: const Text('Edit Server'),
+                            onPressed: () async {
+                              Navigator.pop(context);
+                              context.push(
+                                '/server/${currentServer.id}/edit',
+                                extra: currentServer,
+                              );
+                            },
+                          ),
+                        ],
+                        cancelButton: CupertinoActionSheetAction(
+                          isDefaultAction: true,
+                          child: const Text('Cancel'),
+                          onPressed: () => Navigator.pop(context),
+                        ),
                       ),
-                    ],
-                    cancelButton: CupertinoActionSheetAction(
-                      isDefaultAction: true,
-                      child: const Text('Cancel'),
-                      onPressed: () => Navigator.pop(context),
-                    ),
-                  ),
-                );
-              },
+                    );
+                  },
+                ),
+              ],
             ),
           ),
           child: AuthenticationStateWidget(
@@ -200,6 +218,15 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
             subtitle: 'View system health and status',
             onTap: () {
               context.push('/server/${server.id}/health', extra: server);
+            },
+          ),
+          const SizedBox(height: 12),
+          ActionButtonWidget(
+            icon: CupertinoIcons.bell,
+            title: 'Jobs',
+            subtitle: 'View running, queued, and finished jobs',
+            onTap: () {
+              context.push('/server/${server.id}/jobs', extra: server);
             },
           ),
         ],

--- a/lib/screens/server_files_screen.dart
+++ b/lib/screens/server_files_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class ServerFilesScreen extends StatelessWidget {
   final NasServer server;
@@ -12,6 +13,7 @@ class ServerFilesScreen extends StatelessWidget {
       navigationBar: CupertinoNavigationBar(
         middle: const Text('Files'),
         previousPageTitle: server.name,
+        trailing: JobsBellButton(server: server),
       ),
       child: const SafeArea(
         child: Center(

--- a/lib/screens/server_health_screen.dart
+++ b/lib/screens/server_health_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class ServerHealthScreen extends StatelessWidget {
   final NasServer server;
@@ -12,6 +13,7 @@ class ServerHealthScreen extends StatelessWidget {
       navigationBar: CupertinoNavigationBar(
         middle: const Text('Health'),
         previousPageTitle: server.name,
+        trailing: JobsBellButton(server: server),
       ),
       child: const SafeArea(
         child: Center(

--- a/lib/screens/server_jobs_screen.dart
+++ b/lib/screens/server_jobs_screen.dart
@@ -122,6 +122,7 @@ class _ServerJobsScreenState extends State<ServerJobsScreen> {
       itemBuilder: (context, index) {
         final job = jobs[index];
         return Padding(
+          key: ValueKey(job.id),
           padding: const EdgeInsets.only(bottom: 12),
           child: JobCardWidget(
             job: job,

--- a/lib/screens/server_jobs_screen.dart
+++ b/lib/screens/server_jobs_screen.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import 'package:truehub/models/job.dart';
+import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/providers/jobs_provider.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
+import 'package:truehub/widgets/error_state_widget.dart';
+import 'package:truehub/widgets/job_card_widget.dart';
+
+enum _JobsTab { running, waiting, history }
+
+/// The Jobs view: running/queued/finished TrueNAS jobs for [server], live via
+/// [JobsProvider]. The provider's subscription is owned by
+/// [ServerDetailScreen] (started in its `initState`, stopped in its
+/// `dispose`) so it keeps running - and the nav bar bell keeps working -
+/// while this screen and its siblings are pushed and popped on top of it.
+class ServerJobsScreen extends StatefulWidget {
+  final NasServer server;
+
+  const ServerJobsScreen({super.key, required this.server});
+
+  @override
+  State<ServerJobsScreen> createState() => _ServerJobsScreenState();
+}
+
+class _ServerJobsScreenState extends State<ServerJobsScreen> {
+  _JobsTab _tab = _JobsTab.running;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle: const Text('Jobs'),
+        previousPageTitle: widget.server.name,
+        trailing: Consumer<JobsProvider>(
+          builder: (context, jobsProvider, child) {
+            return CupertinoButton(
+              padding: EdgeInsets.zero,
+              onPressed: jobsProvider.refreshJobs,
+              child: const Icon(CupertinoIcons.refresh),
+            );
+          },
+        ),
+      ),
+      child: SafeArea(
+        child: Consumer<JobsProvider>(
+          builder: (context, jobsProvider, child) {
+            if (jobsProvider.isLoading && !jobsProvider.hasData) {
+              return const Center(child: CupertinoActivityIndicator());
+            }
+
+            if (jobsProvider.error != null && !jobsProvider.hasData) {
+              return ErrorStateWidget(
+                title: 'Jobs Error',
+                message: jobsProvider.error!,
+                onRetry: jobsProvider.refreshJobs,
+              );
+            }
+
+            return Column(
+              children: [
+                const SizedBox(height: 12),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: _JobsOverviewCard(jobsProvider: jobsProvider),
+                ),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: CupertinoSegmentedControl<_JobsTab>(
+                    groupValue: _tab,
+                    onValueChanged: (value) => setState(() => _tab = value),
+                    children: {
+                      _JobsTab.running: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 4,
+                          vertical: 4,
+                        ),
+                        child: Text('Running ${jobsProvider.runningCount}'),
+                      ),
+                      _JobsTab.waiting: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 4,
+                          vertical: 4,
+                        ),
+                        child: Text('Waiting ${jobsProvider.waitingCount}'),
+                      ),
+                      _JobsTab.history: const Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 4,
+                          vertical: 4,
+                        ),
+                        child: Text('History'),
+                      ),
+                    },
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Expanded(child: _buildList(jobsProvider)),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(JobsProvider jobsProvider) {
+    final List<Job> jobs = switch (_tab) {
+      _JobsTab.running => jobsProvider.runningJobs,
+      _JobsTab.waiting => jobsProvider.waitingJobs,
+      _JobsTab.history => jobsProvider.historyJobs,
+    };
+
+    if (jobs.isEmpty) {
+      return _buildEmptyView();
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      itemCount: jobs.length,
+      itemBuilder: (context, index) {
+        final job = jobs[index];
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: JobCardWidget(
+            job: job,
+            onCancel: job.isRunning
+                ? () => context.read<JobsProvider>().abortJob(job.id)
+                : null,
+            onRetry: job.isFailed
+                ? () => context.read<JobsProvider>().rerunJob(job)
+                : null,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyView() {
+    final (title, message) = switch (_tab) {
+      _JobsTab.running => (
+        'Nothing running',
+        'Jobs in progress will appear here.',
+      ),
+      _JobsTab.waiting => (
+        'Nothing queued',
+        'Jobs waiting to start will appear here.',
+      ),
+      _JobsTab.history => (
+        'No finished jobs',
+        'Completed, failed, and aborted jobs will appear here.',
+      ),
+    };
+
+    return EmptyStateWidget(
+      icon: CupertinoIcons.clock,
+      title: title,
+      message: message,
+    );
+  }
+}
+
+class _JobsOverviewCard extends StatelessWidget {
+  final JobsProvider jobsProvider;
+
+  const _JobsOverviewCard({required this.jobsProvider});
+
+  @override
+  Widget build(BuildContext context) {
+    final failedRecently = jobsProvider.recentFailures.length;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: CupertinoColors.systemGrey6,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: CupertinoColors.separator, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          _Stat(
+            count: jobsProvider.runningCount,
+            label: 'Running',
+            color: CupertinoColors.systemBlue,
+          ),
+          _Stat(
+            count: jobsProvider.waitingCount,
+            label: 'Waiting',
+            color: CupertinoColors.systemGrey,
+          ),
+          _Stat(
+            count: failedRecently,
+            label: 'Failed 24h',
+            color: failedRecently > 0
+                ? CupertinoColors.systemRed
+                : CupertinoColors.systemGrey,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Stat extends StatelessWidget {
+  final int count;
+  final String label;
+  final Color color;
+
+  const _Stat({required this.count, required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: [
+          Text(
+            '$count',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 11,
+              color: CupertinoColors.systemGrey,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/server_pools_screen.dart
+++ b/lib/screens/server_pools_screen.dart
@@ -4,6 +4,7 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/screens/pool_detail_screen.dart';
 import 'package:truehub/widgets/connection_error_widget.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class ServerPoolsScreen extends StatefulWidget {
   final NasServer server;
@@ -37,6 +38,7 @@ class _ServerPoolsScreenState extends State<ServerPoolsScreen> {
           child: const Text('Back'),
           onPressed: () => Navigator.pop(context),
         ),
+        trailing: JobsBellButton(server: widget.server),
       ),
       child: SafeArea(
         child: Consumer<PoolProvider>(

--- a/lib/services/api_client_interface.dart
+++ b/lib/services/api_client_interface.dart
@@ -3,6 +3,7 @@ import 'package:truehub/models/server_health.dart';
 import 'package:truehub/models/file_item.dart';
 import 'package:truehub/models/user_info.dart';
 import 'package:truehub/models/app.dart';
+import 'package:truehub/models/job.dart';
 import 'package:truehub/models/system_stats.dart';
 
 /// Interface for TrueNAS API clients to enable dependency injection and testing
@@ -88,4 +89,15 @@ abstract class ApiClientInterface {
   Future<Map<String, dynamic>> getSystemAdvancedConfig();
   Future<String> getSystemProductType();
   Future<bool> isIxHardware();
+
+  // Job management methods
+  Stream<List<Job>> get jobsStream;
+  Future<List<Job>> getJobs();
+  Future<void> subscribeToJobs();
+  Future<void> unsubscribeFromJobs();
+  Future<void> abortJob(int jobId);
+
+  /// Re-submits a finished job's original call, e.g. to retry a failed one.
+  /// Returns the new job's id.
+  Future<int> rerunJob(Job job);
 }

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -9,6 +9,7 @@ import 'package:truehub/models/file_item.dart';
 import 'package:truehub/models/user_info.dart';
 import 'package:truehub/models/connection_error.dart';
 import 'package:truehub/models/app.dart';
+import 'package:truehub/models/job.dart';
 import 'package:truehub/models/system_stats.dart';
 import 'package:truehub/services/network_service.dart';
 import 'package:truehub/services/api_client_interface.dart';
@@ -39,6 +40,17 @@ class TrueNasApiClient implements ApiClientInterface {
   String? _appStatsSubscriptionId;
   bool _isSubscribedToAppStats = false;
   bool _wantsAppStats = false;
+
+  // Job subscription management
+  StreamController<List<Job>>? _jobsController;
+  String? _jobsSubscriptionId;
+  bool _isSubscribedToJobs = false;
+  bool _wantsJobs = false;
+
+  /// Jobs seen so far, keyed by id. `core.get_jobs` collection_update events
+  /// carry one changed job at a time, so this is what turns those deltas into
+  /// the full list [jobsStream] emits.
+  final Map<int, Job> _jobsById = {};
 
   // Keepalive mechanism
   Timer? _keepaliveTimer;
@@ -264,6 +276,8 @@ class TrueNasApiClient implements ApiClientInterface {
     _realtimeSubscriptionId = null;
     _isSubscribedToAppStats = false;
     _appStatsSubscriptionId = null;
+    _isSubscribedToJobs = false;
+    _jobsSubscriptionId = null;
 
     try {
       // Close existing connection
@@ -307,7 +321,8 @@ class TrueNasApiClient implements ApiClientInterface {
   /// True when the UI asked for a stream that is not live on this socket.
   bool get _hasMissingSubscription =>
       (_wantsSystemStats && !_isSubscribedToRealtime) ||
-      (_wantsAppStats && !_isSubscribedToAppStats);
+      (_wantsAppStats && !_isSubscribedToAppStats) ||
+      (_wantsJobs && !_isSubscribedToJobs);
 
   @override
   Future<void> ensureConnectionAlive() async {
@@ -352,6 +367,7 @@ class TrueNasApiClient implements ApiClientInterface {
       if (_wantsSystemStats && !_isSubscribedToRealtime)
         subscribeToSystemStats(),
       if (_wantsAppStats && !_isSubscribedToAppStats) subscribeToAppStats(),
+      if (_wantsJobs && !_isSubscribedToJobs) subscribeToJobs(),
     ]);
   }
 
@@ -437,6 +453,17 @@ class TrueNasApiClient implements ApiClientInterface {
               'TrueNAS API: Received app stats for ${appStatsMap.length} apps',
             );
           }
+        } else if (collection == 'core.get_jobs') {
+          final fields = parameters['fields'].value as Map<String, dynamic>;
+          final job = Job.fromJson(fields);
+          _jobsById[job.id] = job;
+          _jobsController?.add(_jobsById.values.toList());
+
+          if (kDebugMode) {
+            print(
+              'TrueNAS API: Job #${job.id} (${job.method}) -> ${job.state}',
+            );
+          }
         }
       } catch (e) {
         if (kDebugMode) {
@@ -517,6 +544,7 @@ class TrueNasApiClient implements ApiClientInterface {
     );
     await unsubscribeFromSystemStats();
     await unsubscribeFromAppStats();
+    await unsubscribeFromJobs();
     await _client?.close();
     await _wsChannel?.sink.close();
   }
@@ -1244,6 +1272,121 @@ class TrueNasApiClient implements ApiClientInterface {
       await _ensureAuthenticated();
       final result = await _client!.sendRequest('truenas.is_ix_hardware');
       return result as bool;
+    } catch (e) {
+      throw _handleError(e);
+    }
+  }
+
+  // Job management methods
+  @override
+  Future<List<Job>> getJobs() async {
+    try {
+      await _ensureAuthenticated();
+      final result = await _client!.sendRequest('core.get_jobs');
+      final jobs = (result as List<dynamic>).cast<Map<String, dynamic>>().map(
+        Job.fromJson,
+      );
+      _jobsById
+        ..clear()
+        ..addEntries(jobs.map((job) => MapEntry(job.id, job)));
+      return _jobsById.values.toList();
+    } catch (e) {
+      throw _handleError(e);
+    }
+  }
+
+  @override
+  Stream<List<Job>> get jobsStream {
+    _jobsController ??= StreamController<List<Job>>.broadcast();
+    return _jobsController!.stream;
+  }
+
+  @override
+  Future<void> subscribeToJobs() async {
+    _wantsJobs = true;
+
+    if (_isSubscribedToJobs && _hasLiveConnection) {
+      if (kDebugMode) {
+        print('TrueNAS API: Already subscribed to jobs');
+      }
+      return;
+    }
+
+    _isSubscribedToJobs = false;
+    _jobsSubscriptionId = null;
+
+    try {
+      await _ensureAuthenticated();
+
+      _jobsController ??= StreamController<List<Job>>.broadcast();
+
+      _jobsSubscriptionId =
+          await _client!.sendRequest('core.subscribe', ['core.get_jobs'])
+              as String;
+
+      _isSubscribedToJobs = true;
+
+      if (kDebugMode) {
+        print('TrueNAS API: Subscribed to jobs with ID: $_jobsSubscriptionId');
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('TrueNAS API: Failed to subscribe to jobs: $e');
+      }
+      throw _handleError(e);
+    }
+  }
+
+  @override
+  Future<void> unsubscribeFromJobs() async {
+    if (!_isSubscribedToJobs || _jobsSubscriptionId == null) {
+      return;
+    }
+
+    try {
+      if (_hasLiveConnection) {
+        await _client!.sendRequest('core.unsubscribe', [_jobsSubscriptionId!]);
+
+        if (kDebugMode) {
+          print(
+            'TrueNAS API: Unsubscribed from jobs with ID: $_jobsSubscriptionId',
+          );
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('TrueNAS API: Error unsubscribing from jobs: $e');
+      }
+    } finally {
+      _wantsJobs = false;
+      _isSubscribedToJobs = false;
+      _jobsSubscriptionId = null;
+      _jobsById.clear();
+      await _jobsController?.close();
+      _jobsController = null;
+
+      if (kDebugMode) {
+        print('TrueNAS API: Job subscription cleaned up');
+      }
+    }
+  }
+
+  @override
+  Future<void> abortJob(int jobId) async {
+    try {
+      await _ensureAuthenticated();
+      await _client!.sendRequest('core.job_abort', [jobId]);
+    } catch (e) {
+      throw _handleError(e);
+    }
+  }
+
+  @override
+  Future<int> rerunJob(Job job) async {
+    try {
+      await _ensureAuthenticated();
+      final result = await _client!.sendRequest(job.method, job.arguments);
+      return result as int;
     } catch (e) {
       throw _handleError(e);
     }

--- a/lib/widgets/job_card_widget.dart
+++ b/lib/widgets/job_card_widget.dart
@@ -1,0 +1,415 @@
+import 'package:flutter/cupertino.dart';
+import 'package:truehub/models/job.dart';
+import 'package:truehub/widgets/usage_bar.dart';
+
+class _JobVisual {
+  final IconData icon;
+  final Color color;
+  const _JobVisual(this.icon, this.color);
+}
+
+_JobVisual _visualFor(Job job) {
+  if (job.isFinished) {
+    switch (job.state) {
+      case JobState.success:
+        return const _JobVisual(
+          CupertinoIcons.checkmark_circle_fill,
+          CupertinoColors.systemGreen,
+        );
+      case JobState.failed:
+        return const _JobVisual(
+          CupertinoIcons.xmark_circle_fill,
+          CupertinoColors.systemRed,
+        );
+      default:
+        return const _JobVisual(
+          CupertinoIcons.minus_circle_fill,
+          CupertinoColors.systemGrey,
+        );
+    }
+  }
+
+  final method = job.method;
+  if (method.startsWith('zfs.replication')) {
+    return const _JobVisual(
+      CupertinoIcons.arrow_2_circlepath,
+      CupertinoColors.systemTeal,
+    );
+  }
+  if (method.startsWith('pool.scrub')) {
+    return const _JobVisual(CupertinoIcons.shield, CupertinoColors.systemGreen);
+  }
+  if (method.startsWith('cloudsync')) {
+    return const _JobVisual(
+      CupertinoIcons.cloud_upload,
+      CupertinoColors.systemOrange,
+    );
+  }
+  if (method.startsWith('smart.test')) {
+    return const _JobVisual(
+      CupertinoIcons.waveform_path,
+      CupertinoColors.systemPurple,
+    );
+  }
+  if (method.startsWith('zfs.snapshot')) {
+    return const _JobVisual(CupertinoIcons.camera, CupertinoColors.systemGrey);
+  }
+  return const _JobVisual(CupertinoIcons.gear, CupertinoColors.systemBlue);
+}
+
+String _titleFor(Job job) {
+  final description = job.description;
+  if (description != null && description.isNotEmpty) return description;
+
+  final parts = job.method.split('.');
+  final last = parts.isNotEmpty ? parts.last : job.method;
+  final words = last.split('_').where((w) => w.isNotEmpty);
+  if (words.isEmpty) return job.method;
+  return words.map((w) => w[0].toUpperCase() + w.substring(1)).join(' ');
+}
+
+String _relativeTime(DateTime time) {
+  final diff = DateTime.now().difference(time);
+  if (diff.inSeconds < 60) return '${diff.inSeconds}s ago';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  return '${diff.inDays}d ago';
+}
+
+String _durationLabel(Duration duration) {
+  if (duration.inMinutes < 1) return '${duration.inSeconds}s';
+  if (duration.inHours < 1) {
+    return '${duration.inMinutes}m ${duration.inSeconds % 60}s';
+  }
+  return '${duration.inHours}h ${duration.inMinutes % 60}m';
+}
+
+/// A single job in the Jobs screen list: icon, title, live progress while
+/// running, a status badge once finished, and an expandable detail panel
+/// with Cancel/Retry.
+class JobCardWidget extends StatefulWidget {
+  final Job job;
+  final Future<void> Function()? onCancel;
+  final Future<void> Function()? onRetry;
+
+  const JobCardWidget({
+    super.key,
+    required this.job,
+    this.onCancel,
+    this.onRetry,
+  });
+
+  @override
+  State<JobCardWidget> createState() => _JobCardWidgetState();
+}
+
+class _JobCardWidgetState extends State<JobCardWidget> {
+  bool _expanded = false;
+  bool _busy = false;
+
+  Future<void> _handleCancel() async {
+    final onCancel = widget.onCancel;
+    if (onCancel == null || _busy) return;
+    setState(() => _busy = true);
+    try {
+      await onCancel();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _handleRetry() async {
+    final onRetry = widget.onRetry;
+    if (onRetry == null || _busy) return;
+    setState(() => _busy = true);
+    try {
+      await onRetry();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final job = widget.job;
+    final visual = _visualFor(job);
+
+    return GestureDetector(
+      onTap: () => setState(() => _expanded = !_expanded),
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: CupertinoColors.systemGrey6,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: CupertinoColors.separator, width: 0.5),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: visual.color.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(visual.icon, color: visual.color, size: 21),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _titleFor(job),
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        job.isWaiting ? 'Queued · ${job.method}' : job.method,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          color: CupertinoColors.systemGrey,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    if (job.isRunning)
+                      Text(
+                        '${job.progress.percent.round()}%',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                          color: visual.color,
+                        ),
+                      )
+                    else if (job.isFinished)
+                      _StatusBadge(job: job, visual: visual),
+                    const SizedBox(height: 4),
+                    Icon(
+                      _expanded
+                          ? CupertinoIcons.chevron_up
+                          : CupertinoIcons.chevron_down,
+                      size: 14,
+                      color: CupertinoColors.tertiaryLabel,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            if (job.isRunning) ...[
+              const SizedBox(height: 12),
+              UsageBar(
+                usage: job.progress.percent,
+                color: CupertinoColors.systemBlue,
+              ),
+              if (job.progress.description != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  job.progress.description!,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: CupertinoColors.secondaryLabel,
+                  ),
+                ),
+              ],
+              if (job.elapsed != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  'Elapsed ${_durationLabel(job.elapsed!)}',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: CupertinoColors.tertiaryLabel,
+                  ),
+                ),
+              ],
+            ],
+            if (_expanded) ...[
+              const SizedBox(height: 14),
+              Container(
+                padding: const EdgeInsets.only(top: 12),
+                decoration: const BoxDecoration(
+                  border: Border(
+                    top: BorderSide(
+                      color: CupertinoColors.separator,
+                      width: 0.5,
+                    ),
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (job.timeStarted != null)
+                      _MetaRow(
+                        label: 'Started',
+                        value: _relativeTime(job.timeStarted!),
+                      ),
+                    if (job.timeFinished != null) ...[
+                      const SizedBox(height: 8),
+                      _MetaRow(
+                        label: 'Finished',
+                        value: _relativeTime(job.timeFinished!),
+                      ),
+                    ],
+                    const SizedBox(height: 8),
+                    _MetaRow(label: 'Method', value: job.method),
+                    if (job.isFailed && job.error != null) ...[
+                      const SizedBox(height: 10),
+                      Container(
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color: CupertinoColors.systemRed.withValues(
+                            alpha: 0.1,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Icon(
+                              CupertinoIcons.exclamationmark_triangle_fill,
+                              size: 14,
+                              color: CupertinoColors.systemRed,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                job.error!,
+                                style: const TextStyle(
+                                  fontSize: 12,
+                                  color: CupertinoColors.label,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                    if ((job.isRunning && job.abortable) || job.isFailed) ...[
+                      const SizedBox(height: 10),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          if (_busy)
+                            const CupertinoActivityIndicator(radius: 8)
+                          else if (job.isFailed && widget.onRetry != null)
+                            CupertinoButton(
+                              padding: EdgeInsets.zero,
+                              minimumSize: Size.zero,
+                              onPressed: _handleRetry,
+                              child: const Text(
+                                'Retry',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            )
+                          else if (job.isRunning &&
+                              job.abortable &&
+                              widget.onCancel != null)
+                            CupertinoButton(
+                              padding: EdgeInsets.zero,
+                              minimumSize: Size.zero,
+                              onPressed: _handleCancel,
+                              child: const Text(
+                                'Cancel Job',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  color: CupertinoColors.systemRed,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final Job job;
+  final _JobVisual visual;
+
+  const _StatusBadge({required this.job, required this.visual});
+
+  @override
+  Widget build(BuildContext context) {
+    final label = switch (job.state) {
+      JobState.success => 'Success',
+      JobState.failed => 'Failed',
+      JobState.aborted => 'Aborted',
+      _ => 'Done',
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
+      decoration: BoxDecoration(
+        color: visual.color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(7),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: visual.color,
+        ),
+      ),
+    );
+  }
+}
+
+class _MetaRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _MetaRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 12,
+            color: CupertinoColors.systemGrey,
+          ),
+        ),
+        const Spacer(),
+        Flexible(
+          child: Text(
+            value,
+            textAlign: TextAlign.right,
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/jobs_bell_button.dart
+++ b/lib/widgets/jobs_bell_button.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/cupertino.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/providers/jobs_provider.dart';
+
+/// The job-status bell dropped into every server-scoped screen's nav bar
+/// trailing slot. Blue with a count badge while jobs are running, a steady
+/// red dot if nothing is running but something failed recently, otherwise a
+/// dim outline. Always opens the Jobs screen for [server].
+class JobsBellButton extends StatelessWidget {
+  final NasServer server;
+
+  const JobsBellButton({super.key, required this.server});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<JobsProvider>(
+      builder: (context, jobsProvider, child) {
+        final running = jobsProvider.runningCount;
+        final needsAttention = jobsProvider.needsAttention;
+
+        final Color color = running > 0
+            ? CupertinoColors.systemBlue
+            : needsAttention
+            ? CupertinoColors.systemRed
+            : CupertinoColors.systemGrey2;
+
+        return CupertinoButton(
+          padding: EdgeInsets.zero,
+          minimumSize: Size.zero,
+          onPressed: () =>
+              context.push('/server/${server.id}/jobs', extra: server),
+          child: SizedBox(
+            width: 32,
+            height: 32,
+            child: Stack(
+              clipBehavior: Clip.none,
+              alignment: Alignment.center,
+              children: [
+                Icon(CupertinoIcons.bell, color: color, size: 20),
+                if (running > 0)
+                  Positioned(
+                    top: 3,
+                    right: 3,
+                    child: _CountBadge(count: running),
+                  )
+                else if (needsAttention)
+                  const Positioned(top: 5, right: 5, child: _AttentionDot()),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CountBadge extends StatelessWidget {
+  final int count;
+
+  const _CountBadge({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(minWidth: 15, minHeight: 15),
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      decoration: BoxDecoration(
+        color: CupertinoColors.systemBlue,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: CupertinoColors.systemBackground, width: 1.5),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '$count',
+        style: const TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          color: CupertinoColors.white,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+class _AttentionDot extends StatelessWidget {
+  const _AttentionDot();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        color: CupertinoColors.systemRed,
+        shape: BoxShape.circle,
+        border: Border.all(color: CupertinoColors.systemBackground, width: 1.5),
+      ),
+    );
+  }
+}

--- a/lib/widgets/memory_segmented_bar.dart
+++ b/lib/widgets/memory_segmented_bar.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/cupertino.dart';
+import 'package:truehub/models/system_stats.dart';
+
+/// Maps 100% of physical memory into a single horizontal bar split into
+/// Free / ZFS ARC / Apps & Services segments, with a legend of exact values
+/// underneath. Free deliberately excludes the reclaimable ZFS ARC cache, so
+/// the three segments always sum to 100% of [MemoryStats.physicalMemoryTotal].
+class MemorySegmentedBar extends StatelessWidget {
+  final MemoryStats stats;
+  final String Function(int bytes) formatBytes;
+
+  const MemorySegmentedBar({
+    super.key,
+    required this.stats,
+    required this.formatBytes,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: SizedBox(
+            height: 26,
+            child: Row(
+              children: [
+                _Segment(
+                  flex: stats.freeMemoryPercent,
+                  color: CupertinoColors.systemGrey3,
+                  label: '${stats.freeMemoryPercent.round()}%',
+                  labelColor: CupertinoColors.label,
+                ),
+                const SizedBox(width: 1.5),
+                _Segment(
+                  flex: stats.arcUsagePercent,
+                  color: CupertinoColors.systemBlue,
+                  label: '${stats.arcUsagePercent.round()}%',
+                  labelColor: CupertinoColors.white,
+                ),
+                const SizedBox(width: 1.5),
+                _Segment(
+                  flex: stats.appsMemoryPercent,
+                  color: CupertinoColors.systemPurple,
+                  label: '${stats.appsMemoryPercent.round()}%',
+                  labelColor: CupertinoColors.white,
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 14),
+        Container(
+          padding: const EdgeInsets.only(top: 2),
+          decoration: const BoxDecoration(
+            border: Border(
+              top: BorderSide(color: CupertinoColors.separator, width: 0.5),
+            ),
+          ),
+          child: Column(
+            children: [
+              _LegendRow(
+                color: CupertinoColors.systemGrey3,
+                label: 'Free',
+                value: formatBytes(stats.freeMemory),
+                percent: stats.freeMemoryPercent,
+              ),
+              const SizedBox(height: 10),
+              _LegendRow(
+                color: CupertinoColors.systemBlue,
+                label: 'ZFS ARC',
+                value: formatBytes(stats.arcSize),
+                percent: stats.arcUsagePercent,
+              ),
+              const SizedBox(height: 10),
+              _LegendRow(
+                color: CupertinoColors.systemPurple,
+                label: 'Apps & Services',
+                value: formatBytes(stats.appsMemory),
+                percent: stats.appsMemoryPercent,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        const Text(
+          'Free excludes reclaimable ZFS ARC cache, so Free + ZFS ARC + '
+          'Apps always adds up to 100% of physical memory.',
+          style: TextStyle(fontSize: 11, color: CupertinoColors.tertiaryLabel),
+        ),
+      ],
+    );
+  }
+}
+
+class _Segment extends StatelessWidget {
+  final double flex;
+  final Color color;
+  final String label;
+  final Color labelColor;
+
+  const _Segment({
+    required this.flex,
+    required this.color,
+    required this.label,
+    required this.labelColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      // Expanded/Flexible require a strictly positive flex; a genuinely
+      // empty segment (e.g. no ARC cache yet) still renders as a sliver
+      // rather than crashing.
+      flex: flex.round().clamp(1, 100),
+      child: Container(
+        color: color,
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: labelColor,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LegendRow extends StatelessWidget {
+  final Color color;
+  final String label;
+  final String value;
+  final double percent;
+
+  const _LegendRow({
+    required this.color,
+    required this.label,
+    required this.value,
+    required this.percent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 9,
+          height: 9,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 10),
+        Expanded(child: Text(label, style: const TextStyle(fontSize: 13))),
+        Text(
+          value,
+          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        ),
+        SizedBox(
+          width: 40,
+          child: Text(
+            '${percent.round()}%',
+            textAlign: TextAlign.right,
+            style: const TextStyle(
+              fontSize: 12,
+              color: CupertinoColors.systemGrey,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/memory_segmented_bar.dart
+++ b/lib/widgets/memory_segmented_bar.dart
@@ -113,7 +113,7 @@ class _Segment extends StatelessWidget {
       // Expanded/Flexible require a strictly positive flex; a genuinely
       // empty segment (e.g. no ARC cache yet) still renders as a sliver
       // rather than crashing.
-      flex: flex.round().clamp(1, 100),
+      flex: flex.round().clamp(1, 100).toInt(),
       child: Container(
         color: color,
         alignment: Alignment.center,

--- a/lib/widgets/system_stats_widget.dart
+++ b/lib/widgets/system_stats_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/models/system_stats.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
+import 'package:truehub/widgets/memory_segmented_bar.dart';
 import 'package:truehub/widgets/responsive_row.dart';
 import 'package:truehub/widgets/usage_bar.dart';
 
@@ -103,11 +104,7 @@ class SystemStatsWidget extends StatelessWidget {
               cores: statsProvider.cpuCores,
             ),
             _MemoryStatsCard(
-              memoryUsage: statsProvider.memoryUsage,
-              arcUsage: statsProvider.arcUsage,
-              totalMemory: statsProvider.physicalMemoryTotal,
-              availableMemory: statsProvider.physicalMemoryAvailable,
-              arcSize: statsProvider.arcSize,
+              stats: statsProvider.currentStats!.memory,
               formatBytes: statsProvider.formatBytes,
             ),
           ],
@@ -230,24 +227,15 @@ class _CpuStatsCard extends StatelessWidget {
 }
 
 class _MemoryStatsCard extends StatelessWidget {
-  final double memoryUsage;
-  final double arcUsage;
-  final int totalMemory;
-  final int availableMemory;
-  final int arcSize;
+  final MemoryStats stats;
   final String Function(int) formatBytes;
 
-  const _MemoryStatsCard({
-    required this.memoryUsage,
-    required this.arcUsage,
-    required this.totalMemory,
-    required this.availableMemory,
-    required this.arcSize,
-    required this.formatBytes,
-  });
+  const _MemoryStatsCard({required this.stats, required this.formatBytes});
 
   @override
   Widget build(BuildContext context) {
+    final memoryUsage = stats.physicalMemoryUsagePercent;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -281,60 +269,10 @@ class _MemoryStatsCard extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 12),
-          UsageBar(
-            usage: memoryUsage,
-            color: _getMemoryUsageColor(memoryUsage),
-          ),
-          const SizedBox(height: 12),
-          _buildMemoryDetails(),
+          const SizedBox(height: 14),
+          MemorySegmentedBar(stats: stats, formatBytes: formatBytes),
         ],
       ),
-    );
-  }
-
-  Widget _buildMemoryDetails() {
-    return Column(
-      children: [
-        _buildMemoryRow(
-          'Physical',
-          formatBytes(totalMemory - availableMemory),
-          formatBytes(totalMemory),
-          CupertinoColors.systemPurple,
-        ),
-        const SizedBox(height: 6),
-        _buildMemoryRow(
-          'ARC Cache',
-          formatBytes(arcSize),
-          formatBytes(totalMemory),
-          CupertinoColors.systemBlue,
-        ),
-      ],
-    );
-  }
-
-  Widget _buildMemoryRow(String label, String used, String total, Color color) {
-    return Row(
-      children: [
-        Container(
-          width: 8,
-          height: 8,
-          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-        ),
-        const SizedBox(width: 8),
-        Text(
-          label,
-          style: const TextStyle(
-            fontSize: 12,
-            color: CupertinoColors.systemGrey,
-          ),
-        ),
-        const Spacer(),
-        Text(
-          '$used / $total',
-          style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
-        ),
-      ],
     );
   }
 

--- a/test/e2e/complete_edit_flow_test.dart
+++ b/test/e2e/complete_edit_flow_test.dart
@@ -7,6 +7,7 @@ import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/server_provider.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:truehub/navigation/app_router.dart';
@@ -90,6 +91,9 @@ void main() {
         ),
         ChangeNotifierProvider(
           create: (_) => SystemStatsProvider(unifiedServerService),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => JobsProvider(unifiedServerService),
         ),
         ChangeNotifierProvider(create: (_) => ConnectionStatusProvider()),
       ],

--- a/test/helpers/fake_api_client.dart
+++ b/test/helpers/fake_api_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:truehub/models/app.dart';
 import 'package:truehub/models/file_item.dart';
+import 'package:truehub/models/job.dart';
 import 'package:truehub/models/server_health.dart';
 import 'package:truehub/models/system_stats.dart';
 import 'package:truehub/models/user_info.dart';
@@ -403,11 +404,57 @@ class FakeApiClient implements ApiClientInterface {
 
   bool isIxHardwareResult = false;
 
-  /// Closes the stream controllers backing [systemStatsStream] and
-  /// [appStatsStream]. Call from a test's `tearDown` if the fake was used
-  /// with subscriptions.
+  @override
+  Future<List<Job>> getJobs() async {
+    _recordAndMaybeThrow('getJobs');
+    return jobs;
+  }
+
+  List<Job> jobs = [];
+
+  final StreamController<List<Job>> _jobsController =
+      StreamController<List<Job>>.broadcast();
+
+  @override
+  Stream<List<Job>> get jobsStream => _jobsController.stream;
+
+  /// Pushes [jobList] to every current [jobsStream] listener.
+  void emitJobs(List<Job> jobList) => _jobsController.add(jobList);
+
+  @override
+  Future<void> subscribeToJobs() async {
+    _recordAndMaybeThrow('subscribeToJobs');
+  }
+
+  @override
+  Future<void> unsubscribeFromJobs() async {
+    _recordAndMaybeThrow('unsubscribeFromJobs');
+  }
+
+  @override
+  Future<void> abortJob(int jobId) async {
+    _recordAndMaybeThrow('abortJob');
+    lastAbortedJobId = jobId;
+  }
+
+  int? lastAbortedJobId;
+
+  @override
+  Future<int> rerunJob(Job job) async {
+    _recordAndMaybeThrow('rerunJob');
+    lastRerunJob = job;
+    return rerunJobResult;
+  }
+
+  Job? lastRerunJob;
+  int rerunJobResult = 0;
+
+  /// Closes the stream controllers backing [systemStatsStream],
+  /// [appStatsStream] and [jobsStream]. Call from a test's `tearDown` if the
+  /// fake was used with subscriptions.
   Future<void> dispose() async {
     await _systemStatsController.close();
     await _appStatsController.close();
+    await _jobsController.close();
   }
 }

--- a/test/helpers/provider_scope.dart
+++ b/test/helpers/provider_scope.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/server_provider.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
@@ -13,10 +14,10 @@ import 'package:truehub/services/unified_server_service.dart';
 /// (`HomeScreen`, `SettingsScreen`, `ServerDetailScreen`) read from context.
 ///
 /// [ServerProvider] is the one provider every one of those screens needs, so
-/// it is required. [PoolProvider], [AppProvider], [SystemStatsProvider] and
-/// [ConnectionStatusProvider] are only read by `ServerDetailScreen`, and
-/// [TrayProvider] only by `SettingsScreen`; pass one in when a test pumps
-/// the screen that needs it, and leave it out otherwise - a
+/// it is required. [PoolProvider], [AppProvider], [SystemStatsProvider],
+/// [JobsProvider] and [ConnectionStatusProvider] are only read by
+/// `ServerDetailScreen`, and [TrayProvider] only by `SettingsScreen`; pass one
+/// in when a test pumps the screen that needs it, and leave it out otherwise - a
 /// `ChangeNotifierProvider(create: ...)` still backs every one of them by
 /// default so `Provider.of` never fails to resolve, but tests that need to
 /// inspect or seed one should build and pass it explicitly.
@@ -34,6 +35,7 @@ Widget provideAppProviders({
   PoolProvider? poolProvider,
   AppProvider? appProvider,
   SystemStatsProvider? systemStatsProvider,
+  JobsProvider? jobsProvider,
   ConnectionStatusProvider? connectionStatusProvider,
   TrayProvider? trayProvider,
 }) {
@@ -59,6 +61,11 @@ Widget provideAppProviders({
             )
           : ChangeNotifierProvider<SystemStatsProvider>(
               create: (_) => SystemStatsProvider(service),
+            ),
+      jobsProvider != null
+          ? ChangeNotifierProvider<JobsProvider>.value(value: jobsProvider)
+          : ChangeNotifierProvider<JobsProvider>(
+              create: (_) => JobsProvider(service),
             ),
       connectionStatusProvider != null
           ? ChangeNotifierProvider<ConnectionStatusProvider>.value(

--- a/test/models/job_test.dart
+++ b/test/models/job_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/models/job.dart';
+
+void main() {
+  group('JobProgress', () {
+    test('fromJson parses percent and description', () {
+      final progress = JobProgress.fromJson({
+        'percent': 42.5,
+        'description': 'Copying files',
+      });
+      expect(progress.percent, equals(42.5));
+      expect(progress.description, equals('Copying files'));
+    });
+
+    test('fromJson defaults percent to 0 and description to null', () {
+      final progress = JobProgress.fromJson({});
+      expect(progress.percent, equals(0));
+      expect(progress.description, isNull);
+    });
+
+    test('fromJson handles null json', () {
+      final progress = JobProgress.fromJson(null);
+      expect(progress.percent, equals(0));
+    });
+
+    test('toJson round-trips', () {
+      const progress = JobProgress(percent: 10, description: 'Step 1');
+      final roundTripped = JobProgress.fromJson(progress.toJson());
+      expect(roundTripped, equals(progress));
+    });
+  });
+
+  group('Job.fromJson', () {
+    test('parses a running job', () {
+      final job = Job.fromJson({
+        'id': 12,
+        'method': 'pool.scrub.scrub',
+        'arguments': ['tank'],
+        'description': "Scrubbing pool 'tank'",
+        'progress': {'percent': 34.0, 'description': 'Scanning'},
+        'state': 'RUNNING',
+        'time_started': {r'$date': 1700000000000},
+        'time_finished': null,
+        'abortable': true,
+      });
+
+      expect(job.id, equals(12));
+      expect(job.method, equals('pool.scrub.scrub'));
+      expect(job.arguments, equals(['tank']));
+      expect(job.description, equals("Scrubbing pool 'tank'"));
+      expect(job.progress.percent, equals(34.0));
+      expect(job.state, equals(JobState.running));
+      expect(
+        job.timeStarted,
+        equals(DateTime.fromMillisecondsSinceEpoch(1700000000000)),
+      );
+      expect(job.timeFinished, isNull);
+      expect(job.abortable, isTrue);
+      expect(job.isRunning, isTrue);
+      expect(job.isWaiting, isFalse);
+      expect(job.isFinished, isFalse);
+      expect(job.isFailed, isFalse);
+    });
+
+    test('parses a failed job with an error', () {
+      final job = Job.fromJson({
+        'id': 7,
+        'method': 'cloudsync.sync',
+        'state': 'FAILED',
+        'error': 'Connection timed out',
+        'logs_excerpt': 'traceback...',
+      });
+
+      expect(job.state, equals(JobState.failed));
+      expect(job.isFinished, isTrue);
+      expect(job.isFailed, isTrue);
+      expect(job.error, equals('Connection timed out'));
+      expect(job.logsExcerpt, equals('traceback...'));
+    });
+
+    test('defaults missing fields', () {
+      final job = Job.fromJson({'id': 1});
+      expect(job.method, equals(''));
+      expect(job.arguments, isEmpty);
+      expect(job.description, isNull);
+      expect(job.progress.percent, equals(0));
+      expect(job.state, equals(JobState.unknown));
+      expect(job.timeStarted, isNull);
+      expect(job.timeFinished, isNull);
+      expect(job.abortable, isFalse);
+    });
+
+    test('parses every known state', () {
+      for (final entry in {
+        'WAITING': JobState.waiting,
+        'RUNNING': JobState.running,
+        'SUCCESS': JobState.success,
+        'FAILED': JobState.failed,
+        'ABORTED': JobState.aborted,
+        'HELD': JobState.held,
+        'SOMETHING_ELSE': JobState.unknown,
+      }.entries) {
+        final job = Job.fromJson({'id': 1, 'state': entry.key});
+        expect(job.state, equals(entry.value), reason: entry.key);
+      }
+    });
+
+    test('isWaiting is true for both WAITING and HELD', () {
+      expect(Job.fromJson({'id': 1, 'state': 'WAITING'}).isWaiting, isTrue);
+      expect(Job.fromJson({'id': 1, 'state': 'HELD'}).isWaiting, isTrue);
+      expect(Job.fromJson({'id': 1, 'state': 'RUNNING'}).isWaiting, isFalse);
+    });
+
+    test('isFinished is true for SUCCESS, FAILED and ABORTED', () {
+      for (final state in ['SUCCESS', 'FAILED', 'ABORTED']) {
+        expect(
+          Job.fromJson({'id': 1, 'state': state}).isFinished,
+          isTrue,
+          reason: state,
+        );
+      }
+      expect(Job.fromJson({'id': 1, 'state': 'RUNNING'}).isFinished, isFalse);
+    });
+
+    test('accepts a raw epoch-millisecond number for datetime fields', () {
+      final job = Job.fromJson({'id': 1, 'time_started': 1700000000000});
+      expect(
+        job.timeStarted,
+        equals(DateTime.fromMillisecondsSinceEpoch(1700000000000)),
+      );
+    });
+
+    test('accepts an ISO 8601 string for datetime fields', () {
+      final job = Job.fromJson({
+        'id': 1,
+        'time_started': '2023-11-14T22:13:20.000Z',
+      });
+      expect(job.timeStarted, isNotNull);
+      expect(job.timeStarted!.year, equals(2023));
+    });
+
+    test('toJson round-trips through fromJson', () {
+      final job = Job.fromJson({
+        'id': 5,
+        'method': 'zfs.replication.run',
+        'arguments': ['backup'],
+        'description': 'Replicating',
+        'progress': {'percent': 50.0},
+        'state': 'RUNNING',
+        'time_started': {r'$date': 1700000000000},
+        'abortable': true,
+      });
+
+      final roundTripped = Job.fromJson(job.toJson());
+      expect(roundTripped, equals(job));
+    });
+  });
+
+  group('Job.elapsed', () {
+    test('is null when the job has not started', () {
+      final job = Job.fromJson({'id': 1, 'state': 'WAITING'});
+      expect(job.elapsed, isNull);
+    });
+
+    test('is measured against time_finished once the job is done', () {
+      final job = Job.fromJson({
+        'id': 1,
+        'state': 'SUCCESS',
+        'time_started': {r'$date': 1700000000000},
+        'time_finished': {r'$date': 1700000010000},
+      });
+      expect(job.elapsed, equals(const Duration(seconds: 10)));
+    });
+
+    test('is measured against now while still running', () {
+      final started = DateTime.now().subtract(const Duration(seconds: 5));
+      final job = Job.fromJson({
+        'id': 1,
+        'state': 'RUNNING',
+        'time_started': {r'$date': started.millisecondsSinceEpoch},
+      });
+      expect(job.elapsed!.inSeconds, greaterThanOrEqualTo(5));
+    });
+  });
+
+  group('Job equality', () {
+    test('two jobs with identical fields are equal', () {
+      final a = Job.fromJson({'id': 1, 'method': 'x', 'state': 'RUNNING'});
+      final b = Job.fromJson({'id': 1, 'method': 'x', 'state': 'RUNNING'});
+      expect(a, equals(b));
+    });
+
+    test('jobs differing by id are not equal', () {
+      final a = Job.fromJson({'id': 1, 'state': 'RUNNING'});
+      final b = Job.fromJson({'id': 2, 'state': 'RUNNING'});
+      expect(a == b, isFalse);
+    });
+  });
+}

--- a/test/models/system_stats_test.dart
+++ b/test/models/system_stats_test.dart
@@ -177,6 +177,49 @@ void main() {
       expect(mem.arcUsagePercent, equals(0.0));
     });
 
+    test('freeMemory/appsMemory split available/used around the ARC', () {
+      // total 1000, available 600 (of which 200 is ARC), so:
+      // apps = total - available = 400
+      // free = available - arc = 400
+      const mem = MemoryStats(
+        arcSize: 200,
+        arcFreeMemory: 0,
+        arcAvailableMemory: 0,
+        physicalMemoryTotal: 1000,
+        physicalMemoryAvailable: 600,
+      );
+      expect(mem.appsMemory, equals(400));
+      expect(mem.freeMemory, equals(400));
+    });
+
+    test(
+      'freeMemoryPercent + arcUsagePercent + appsMemoryPercent sum to 100',
+      () {
+        const mem = MemoryStats(
+          arcSize: 186,
+          arcFreeMemory: 0,
+          arcAvailableMemory: 0,
+          physicalMemoryTotal: 640,
+          physicalMemoryAvailable: 412,
+        );
+        final sum =
+            mem.freeMemoryPercent + mem.arcUsagePercent + mem.appsMemoryPercent;
+        expect(sum, closeTo(100.0, 0.0001));
+      },
+    );
+
+    test('freeMemory/appsMemory guard division by zero for percentages', () {
+      const mem = MemoryStats(
+        arcSize: 0,
+        arcFreeMemory: 0,
+        arcAvailableMemory: 0,
+        physicalMemoryTotal: 0,
+        physicalMemoryAvailable: 0,
+      );
+      expect(mem.freeMemoryPercent, equals(0.0));
+      expect(mem.appsMemoryPercent, equals(0.0));
+    });
+
     test('equality holds for equal instances and differs on change', () {
       const a = MemoryStats(
         arcSize: 1,

--- a/test/navigation/add_server_navigation_test.dart
+++ b/test/navigation/add_server_navigation_test.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:truehub/navigation/app_router.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/server_provider.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
@@ -64,6 +65,9 @@ void main() {
         ),
         ChangeNotifierProvider(
           create: (_) => SystemStatsProvider(unifiedServerService),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => JobsProvider(unifiedServerService),
         ),
         ChangeNotifierProvider(create: (_) => ConnectionStatusProvider()),
       ],

--- a/test/providers/jobs_provider_test.dart
+++ b/test/providers/jobs_provider_test.dart
@@ -109,6 +109,34 @@ void main() {
       expect(provider.isSubscribed, isFalse);
       expect(provider.error, 'No API client configured');
     });
+
+    test('switching from a configured server to one without credentials '
+        'clears the previous client rather than keeping it live', () async {
+      // Regression test: setApiClient used to leave `_apiClient` pointed at
+      // the previous server whenever the new server had no credentials (or
+      // client creation failed), so abortJob/rerunJob/subscribeToJobs could
+      // silently keep acting on the old server after switching.
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+      expect(provider.isSubscribed, isTrue);
+
+      final orphanServer = NasServer.create(
+        name: 'No Credentials Server',
+        host: '192.168.1.200',
+        username: 'admin',
+        password: 'password',
+      );
+      await provider.setApiClient(orphanServer);
+
+      // The old client's subscription was torn down by setApiClient...
+      expect(provider.isSubscribed, isFalse);
+      // ...and nothing new is configured, so every action fails closed
+      // instead of quietly reaching the previous (Test Server) client.
+      final aborted = await provider.abortJob(1);
+      expect(aborted, isFalse);
+      expect(provider.error, 'No API client configured');
+      expect(fakeClient.lastAbortedJobId, isNull);
+    });
   });
 
   group('JobsProvider - subscribeToJobs', () {

--- a/test/providers/jobs_provider_test.dart
+++ b/test/providers/jobs_provider_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/models/job.dart';
+import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/providers/jobs_provider.dart';
+import 'package:truehub/services/database.dart';
+import 'package:truehub/services/unified_server_service.dart';
+
+import '../helpers/fake_api_client.dart';
+import '../helpers/test_database.dart';
+import '../helpers/test_providers.dart';
+
+Job _job({
+  int id = 1,
+  String method = 'pool.scrub.scrub',
+  String state = 'RUNNING',
+  double percent = 0,
+  DateTime? timeFinished,
+  bool abortable = true,
+  String? error,
+}) {
+  return Job.fromJson({
+    'id': id,
+    'method': method,
+    'state': state,
+    'progress': {'percent': percent},
+    'time_started': {r'$date': DateTime.now().millisecondsSinceEpoch},
+    if (timeFinished != null)
+      'time_finished': {r'$date': timeFinished.millisecondsSinceEpoch},
+    'abortable': abortable,
+    'error': ?error,
+  });
+}
+
+void main() {
+  late AppDatabase database;
+  late UnifiedServerService serverService;
+  late JobsProvider provider;
+  late FakeApiClient fakeClient;
+  late NasServer testServer;
+
+  setUp(() async {
+    await TestProviders.cleanupTestEnvironment();
+    TestProviders.setupTestEnvironment();
+
+    database = createTestDatabase();
+    serverService = await TestProviders.createMockUnifiedServerService(
+      database: database,
+    );
+    provider = JobsProvider(serverService);
+    fakeClient = FakeApiClient();
+
+    testServer = NasServer.create(
+      name: 'Test Server',
+      host: '192.168.1.100',
+      username: 'admin',
+      password: 'password',
+    );
+
+    await serverService.saveServerConfig(
+      server: testServer,
+      password: 'password',
+    );
+    TestProviders.mockApiClientManager.addMockClient(testServer.id, fakeClient);
+  });
+
+  tearDown(() async {
+    provider.dispose();
+    await fakeClient.dispose();
+    await serverService.dispose();
+    await TestProviders.cleanupTestEnvironment();
+  });
+
+  group('JobsProvider - initial state', () {
+    test('has no jobs and is not subscribed or loading', () {
+      expect(provider.jobs, isEmpty);
+      expect(provider.hasData, isFalse);
+      expect(provider.isLoading, isFalse);
+      expect(provider.isSubscribed, isFalse);
+      expect(provider.error, isNull);
+      expect(provider.runningJobs, isEmpty);
+      expect(provider.waitingJobs, isEmpty);
+      expect(provider.historyJobs, isEmpty);
+      expect(provider.runningCount, 0);
+      expect(provider.waitingCount, 0);
+      expect(provider.recentFailures, isEmpty);
+      expect(provider.needsAttention, isFalse);
+    });
+  });
+
+  group('JobsProvider - setApiClient', () {
+    test('with a known server obtains an API client', () async {
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+      expect(provider.isSubscribed, isTrue);
+      expect(provider.error, isNull);
+    });
+
+    test('missing credentials leaves the client unset', () async {
+      final orphanServer = NasServer.create(
+        name: 'No Credentials Server',
+        host: '192.168.1.200',
+        username: 'admin',
+        password: 'password',
+      );
+
+      await provider.setApiClient(orphanServer);
+      await provider.subscribeToJobs();
+
+      expect(provider.isSubscribed, isFalse);
+      expect(provider.error, 'No API client configured');
+    });
+  });
+
+  group('JobsProvider - subscribeToJobs', () {
+    test('seeds jobs from getJobs before listening to the stream', () async {
+      fakeClient.jobs = [_job(id: 1), _job(id: 2, state: 'WAITING')];
+      await provider.setApiClient(testServer);
+
+      await provider.subscribeToJobs();
+
+      expect(provider.isSubscribed, isTrue);
+      expect(fakeClient.calls, contains('getJobs'));
+      expect(fakeClient.calls, contains('subscribeToJobs'));
+      expect(provider.jobs.length, 2);
+      expect(provider.runningCount, 1);
+      expect(provider.waitingCount, 1);
+    });
+
+    test('receives further updates through the jobs stream', () async {
+      await provider.setApiClient(testServer);
+
+      var notifications = 0;
+      provider.addListener(() => notifications++);
+
+      await provider.subscribeToJobs();
+
+      fakeClient.emitJobs([_job(id: 3, percent: 55)]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.jobs.length, 1);
+      expect(provider.jobs.first.progress.percent, 55);
+      expect(notifications, greaterThan(0));
+    });
+
+    test('is idempotent when already subscribed', () async {
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+      final callsAfterFirst = fakeClient.calls
+          .where((c) => c == 'subscribeToJobs')
+          .length;
+
+      await provider.subscribeToJobs();
+      final callsAfterSecond = fakeClient.calls
+          .where((c) => c == 'subscribeToJobs')
+          .length;
+
+      expect(callsAfterSecond, callsAfterFirst);
+    });
+
+    test('without a client sets an error', () async {
+      await provider.subscribeToJobs();
+      expect(provider.isSubscribed, isFalse);
+      expect(provider.error, 'No API client configured');
+    });
+
+    test('a subscribeToJobs failure sets an error', () async {
+      await provider.setApiClient(testServer);
+      fakeClient.failingMethods.add('subscribeToJobs');
+
+      await provider.subscribeToJobs();
+
+      expect(provider.isSubscribed, isFalse);
+      expect(provider.isLoading, isFalse);
+      expect(provider.error, contains('Failed to subscribe'));
+    });
+  });
+
+  group('JobsProvider - job classification', () {
+    test('runningJobs/waitingJobs/historyJobs partition correctly', () async {
+      fakeClient.jobs = [
+        _job(id: 1, state: 'RUNNING'),
+        _job(id: 2, state: 'WAITING'),
+        _job(id: 3, state: 'HELD'),
+        _job(id: 4, state: 'SUCCESS', timeFinished: DateTime.now()),
+        _job(id: 5, state: 'FAILED', timeFinished: DateTime.now()),
+      ];
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+
+      expect(provider.runningJobs.map((j) => j.id), [1]);
+      expect(provider.waitingJobs.map((j) => j.id), containsAll([2, 3]));
+      expect(provider.historyJobs.map((j) => j.id), containsAll([4, 5]));
+    });
+
+    test('historyJobs sorts most recently finished first', () async {
+      final older = DateTime.now().subtract(const Duration(hours: 2));
+      final newer = DateTime.now();
+      fakeClient.jobs = [
+        _job(id: 1, state: 'SUCCESS', timeFinished: older),
+        _job(id: 2, state: 'SUCCESS', timeFinished: newer),
+      ];
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+
+      expect(provider.historyJobs.map((j) => j.id).toList(), [2, 1]);
+    });
+
+    test(
+      'recentFailures only includes failures within the attention window',
+      () async {
+        fakeClient.jobs = [
+          _job(
+            id: 1,
+            state: 'FAILED',
+            timeFinished: DateTime.now().subtract(const Duration(hours: 1)),
+          ),
+          _job(
+            id: 2,
+            state: 'FAILED',
+            timeFinished: DateTime.now().subtract(const Duration(hours: 30)),
+          ),
+        ];
+        await provider.setApiClient(testServer);
+        await provider.subscribeToJobs();
+
+        expect(provider.recentFailures.map((j) => j.id).toList(), [1]);
+      },
+    );
+
+    test(
+      'needsAttention is true only when idle with a recent failure',
+      () async {
+        fakeClient.jobs = [
+          _job(id: 1, state: 'FAILED', timeFinished: DateTime.now()),
+        ];
+        await provider.setApiClient(testServer);
+        await provider.subscribeToJobs();
+        expect(provider.needsAttention, isTrue);
+
+        fakeClient.emitJobs([
+          _job(id: 1, state: 'FAILED', timeFinished: DateTime.now()),
+          _job(id: 2, state: 'RUNNING'),
+        ]);
+        await Future<void>.delayed(Duration.zero);
+        expect(provider.needsAttention, isFalse);
+      },
+    );
+  });
+
+  group('JobsProvider - abortJob / rerunJob', () {
+    test('abortJob delegates to the API client and returns true', () async {
+      await provider.setApiClient(testServer);
+      final result = await provider.abortJob(42);
+      expect(result, isTrue);
+      expect(fakeClient.lastAbortedJobId, 42);
+    });
+
+    test('abortJob surfaces a failure', () async {
+      await provider.setApiClient(testServer);
+      fakeClient.failingMethods.add('abortJob');
+
+      final result = await provider.abortJob(42);
+
+      expect(result, isFalse);
+      expect(provider.error, contains('Failed to cancel job'));
+    });
+
+    test('abortJob without a client sets an error', () async {
+      final result = await provider.abortJob(42);
+      expect(result, isFalse);
+      expect(provider.error, 'No API client configured');
+    });
+
+    test('rerunJob delegates to the API client and returns true', () async {
+      await provider.setApiClient(testServer);
+      final job = _job(id: 9, state: 'FAILED');
+
+      final result = await provider.rerunJob(job);
+
+      expect(result, isTrue);
+      expect(fakeClient.lastRerunJob, job);
+    });
+
+    test('rerunJob surfaces a failure', () async {
+      await provider.setApiClient(testServer);
+      fakeClient.failingMethods.add('rerunJob');
+
+      final result = await provider.rerunJob(_job(id: 9, state: 'FAILED'));
+
+      expect(result, isFalse);
+      expect(provider.error, contains('Failed to retry job'));
+    });
+  });
+
+  group('JobsProvider - refreshJobs', () {
+    test('starts a subscription when not yet subscribed', () async {
+      await provider.setApiClient(testServer);
+
+      await provider.refreshJobs();
+
+      expect(provider.isSubscribed, isTrue);
+    });
+
+    test('re-fetches jobs without touching the subscription', () async {
+      fakeClient.jobs = [_job(id: 1)];
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+
+      fakeClient.jobs = [_job(id: 1), _job(id: 2)];
+      await provider.refreshJobs();
+
+      expect(provider.jobs.length, 2);
+      final subscribeCalls = fakeClient.calls
+          .where((c) => c == 'subscribeToJobs')
+          .length;
+      expect(subscribeCalls, 1);
+    });
+
+    test('without a client sets an error', () async {
+      await provider.refreshJobs();
+      expect(provider.error, 'No API client configured');
+    });
+  });
+
+  group('JobsProvider - unsubscribeFromJobs', () {
+    test('clears jobs and subscription state', () async {
+      fakeClient.jobs = [_job(id: 1)];
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+      expect(provider.hasData, isTrue);
+
+      await provider.unsubscribeFromJobs();
+
+      expect(provider.isSubscribed, isFalse);
+      expect(provider.jobs, isEmpty);
+      expect(fakeClient.calls, contains('unsubscribeFromJobs'));
+    });
+
+    test('is a no-op when not subscribed', () async {
+      await provider.unsubscribeFromJobs();
+      expect(provider.isSubscribed, isFalse);
+      expect(fakeClient.calls.contains('unsubscribeFromJobs'), isFalse);
+    });
+  });
+
+  group('JobsProvider - dispose', () {
+    test('unsubscribes and releases the active client', () async {
+      final scoped = JobsProvider(serverService);
+      await scoped.setApiClient(testServer);
+      await scoped.subscribeToJobs();
+
+      scoped.dispose();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        TestProviders.mockApiClientManager.wasMethodCalled(
+          'releaseClient:${testServer.id}',
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/screens/pool_detail_screen_test.dart
+++ b/test/screens/pool_detail_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/dataset_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/screens/dataset_detail_screen.dart';
 import 'package:truehub/screens/pool_detail_screen.dart';
 import 'package:truehub/services/database.dart';
@@ -18,6 +19,7 @@ void main() {
   late AppDatabase database;
   late UnifiedServerService serverService;
   late DatasetProvider datasetProvider;
+  late JobsProvider jobsProvider;
   late FakeApiClient fakeClient;
   late NasServer testServer;
 
@@ -30,6 +32,7 @@ void main() {
       database: database,
     );
     datasetProvider = DatasetProvider(serverService);
+    jobsProvider = JobsProvider(serverService);
     fakeClient = FakeApiClient();
 
     testServer = NasServer.create(
@@ -48,15 +51,18 @@ void main() {
 
   tearDown(() async {
     await TestProviders.disposeTestStack(
-      providers: [datasetProvider],
+      providers: [datasetProvider, jobsProvider],
       service: serverService,
       database: database,
     );
   });
 
   Widget wrap(Map<String, dynamic> pool, {NasServer? server}) {
-    return ChangeNotifierProvider<DatasetProvider>.value(
-      value: datasetProvider,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<DatasetProvider>.value(value: datasetProvider),
+        ChangeNotifierProvider<JobsProvider>.value(value: jobsProvider),
+      ],
       child: CupertinoApp(
         home: PoolDetailScreen(server: server ?? testServer, pool: pool),
       ),

--- a/test/screens/server_pools_screen_test.dart
+++ b/test/screens/server_pools_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/dataset_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/screens/server_pools_screen.dart';
 import 'package:truehub/services/database.dart';
@@ -18,6 +19,7 @@ void main() {
   late UnifiedServerService serverService;
   late PoolProvider poolProvider;
   late DatasetProvider datasetProvider;
+  late JobsProvider jobsProvider;
   late FakeApiClient fakeClient;
   late NasServer testServer;
 
@@ -31,6 +33,7 @@ void main() {
     );
     poolProvider = PoolProvider(serverService);
     datasetProvider = DatasetProvider(serverService);
+    jobsProvider = JobsProvider(serverService);
     fakeClient = FakeApiClient();
 
     testServer = NasServer.create(
@@ -52,6 +55,7 @@ void main() {
   tearDown(() async {
     poolProvider.dispose();
     datasetProvider.dispose();
+    jobsProvider.dispose();
     await fakeClient.dispose();
     await TestProviders.disposeTestStack(
       service: serverService,
@@ -64,6 +68,7 @@ void main() {
       providers: [
         ChangeNotifierProvider<PoolProvider>.value(value: poolProvider),
         ChangeNotifierProvider<DatasetProvider>.value(value: datasetProvider),
+        ChangeNotifierProvider<JobsProvider>.value(value: jobsProvider),
       ],
       child: CupertinoApp(home: ServerPoolsScreen(server: testServer)),
     );
@@ -91,6 +96,7 @@ void main() {
             ChangeNotifierProvider<DatasetProvider>.value(
               value: datasetProvider,
             ),
+            ChangeNotifierProvider<JobsProvider>.value(value: jobsProvider),
           ],
           child: CupertinoApp(home: ServerPoolsScreen(server: testServer)),
         ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,6 +14,7 @@ import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/providers/dataset_provider.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/providers/system_stats_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:truehub/providers/tray_provider.dart';
 import 'package:truehub/services/database.dart';
@@ -78,6 +79,9 @@ void main() {
           ),
           ChangeNotifierProvider(
             create: (context) => SystemStatsProvider(unifiedServerService),
+          ),
+          ChangeNotifierProvider(
+            create: (context) => JobsProvider(unifiedServerService),
           ),
           ChangeNotifierProvider(create: (context) => TrayProvider()),
         ],

--- a/test/widgets/jobs_bell_button_test.dart
+++ b/test/widgets/jobs_bell_button_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:truehub/models/job.dart';
+import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/providers/jobs_provider.dart';
+import 'package:truehub/services/database.dart';
+import 'package:truehub/services/unified_server_service.dart';
+import 'package:truehub/widgets/jobs_bell_button.dart';
+
+import '../helpers/fake_api_client.dart';
+import '../helpers/test_database.dart';
+import '../helpers/test_providers.dart';
+
+Job _job({required int id, required String state, DateTime? timeFinished}) {
+  return Job.fromJson({
+    'id': id,
+    'method': 'pool.scrub.scrub',
+    'state': state,
+    if (timeFinished != null)
+      'time_finished': {r'$date': timeFinished.millisecondsSinceEpoch},
+  });
+}
+
+Widget _wrap(JobsProvider provider) {
+  return ChangeNotifierProvider<JobsProvider>.value(
+    value: provider,
+    child: CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Center(
+          child: JobsBellButton(
+            server: NasServer.create(
+              name: 'Test Server',
+              host: '192.168.1.100',
+              username: 'admin',
+              password: 'password',
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Icon _bellIcon(WidgetTester tester) =>
+    tester.widget<Icon>(find.byIcon(CupertinoIcons.bell));
+
+void main() {
+  late AppDatabase database;
+  late UnifiedServerService serverService;
+  late JobsProvider provider;
+  late FakeApiClient fakeClient;
+  late NasServer testServer;
+
+  setUp(() async {
+    await TestProviders.cleanupTestEnvironment();
+    TestProviders.setupTestEnvironment();
+
+    database = createTestDatabase();
+    serverService = await TestProviders.createMockUnifiedServerService(
+      database: database,
+    );
+    provider = JobsProvider(serverService);
+    fakeClient = FakeApiClient();
+
+    testServer = NasServer.create(
+      name: 'Test Server',
+      host: '192.168.1.100',
+      username: 'admin',
+      password: 'password',
+    );
+    await serverService.saveServerConfig(
+      server: testServer,
+      password: 'password',
+    );
+    TestProviders.mockApiClientManager.addMockClient(testServer.id, fakeClient);
+  });
+
+  tearDown(() async {
+    provider.dispose();
+    await fakeClient.dispose();
+    await serverService.dispose();
+    await TestProviders.cleanupTestEnvironment();
+  });
+
+  testWidgets('idle state: dim bell, no badge', (tester) async {
+    await tester.pumpWidget(_wrap(provider));
+
+    expect(find.byIcon(CupertinoIcons.bell), findsOneWidget);
+    expect(_bellIcon(tester).color, CupertinoColors.systemGrey2);
+    // No count badge and no red dot.
+    expect(find.textContaining(RegExp(r'^\d+$')), findsNothing);
+  });
+
+  testWidgets('active state: blue bell with a running count badge', (
+    tester,
+  ) async {
+    fakeClient.jobs = [
+      _job(id: 1, state: 'RUNNING'),
+      _job(id: 2, state: 'RUNNING'),
+    ];
+    await provider.setApiClient(testServer);
+    await provider.subscribeToJobs();
+
+    await tester.pumpWidget(_wrap(provider));
+
+    expect(_bellIcon(tester).color, CupertinoColors.systemBlue);
+    expect(find.text('2'), findsOneWidget);
+  });
+
+  testWidgets(
+    'needs-attention state: red bell with no count when idle after a failure',
+    (tester) async {
+      fakeClient.jobs = [
+        _job(id: 1, state: 'FAILED', timeFinished: DateTime.now()),
+      ];
+      await provider.setApiClient(testServer);
+      await provider.subscribeToJobs();
+
+      await tester.pumpWidget(_wrap(provider));
+
+      expect(_bellIcon(tester).color, CupertinoColors.systemRed);
+      expect(find.textContaining(RegExp(r'^\d+$')), findsNothing);
+    },
+  );
+
+  testWidgets('running jobs take priority over a stale failure', (
+    tester,
+  ) async {
+    fakeClient.jobs = [
+      _job(id: 1, state: 'FAILED', timeFinished: DateTime.now()),
+      _job(id: 2, state: 'RUNNING'),
+    ];
+    await provider.setApiClient(testServer);
+    await provider.subscribeToJobs();
+
+    await tester.pumpWidget(_wrap(provider));
+
+    expect(_bellIcon(tester).color, CupertinoColors.systemBlue);
+    expect(find.text('1'), findsOneWidget);
+  });
+}

--- a/test/widgets/pool_card_widget_test.dart
+++ b/test/widgets/pool_card_widget_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/dataset_provider.dart';
+import 'package:truehub/providers/jobs_provider.dart';
 import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
 import 'package:truehub/widgets/pool_card_widget.dart';
@@ -23,6 +24,7 @@ void main() {
     Map<String, dynamic> pool, {
     double width = 375,
     DatasetProvider? datasetProvider,
+    JobsProvider? jobsProvider,
   }) {
     final card = PoolCardWidget(pool: pool, server: testServer);
     final home = Center(
@@ -32,11 +34,18 @@ void main() {
       ),
     );
 
-    if (datasetProvider == null) {
+    final providers = [
+      if (datasetProvider != null)
+        ChangeNotifierProvider<DatasetProvider>.value(value: datasetProvider),
+      if (jobsProvider != null)
+        ChangeNotifierProvider<JobsProvider>.value(value: jobsProvider),
+    ];
+
+    if (providers.isEmpty) {
       return CupertinoApp(home: home);
     }
-    return ChangeNotifierProvider<DatasetProvider>.value(
-      value: datasetProvider,
+    return MultiProvider(
+      providers: providers,
       child: CupertinoApp(home: home),
     );
   }
@@ -259,6 +268,7 @@ void main() {
     late AppDatabase database;
     late UnifiedServerService unifiedServerService;
     late DatasetProvider datasetProvider;
+    late JobsProvider jobsProvider;
 
     setUp(() async {
       await TestProviders.cleanupTestEnvironment();
@@ -268,11 +278,12 @@ void main() {
         database: database,
       );
       datasetProvider = DatasetProvider(unifiedServerService);
+      jobsProvider = JobsProvider(unifiedServerService);
     });
 
     tearDown(() async {
       await TestProviders.disposeTestStack(
-        providers: [datasetProvider],
+        providers: [datasetProvider, jobsProvider],
         service: unifiedServerService,
         database: database,
       );
@@ -282,11 +293,11 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        wrap({
-          'name': 'tank',
-          'status': 'ONLINE',
-          'healthy': true,
-        }, datasetProvider: datasetProvider),
+        wrap(
+          {'name': 'tank', 'status': 'ONLINE', 'healthy': true},
+          datasetProvider: datasetProvider,
+          jobsProvider: jobsProvider,
+        ),
       );
 
       await tester.tap(find.byType(PoolCardWidget));

--- a/test/widgets/system_stats_widget_test.dart
+++ b/test/widgets/system_stats_widget_test.dart
@@ -313,9 +313,14 @@ void main() {
         expect(find.text('7.5 ops/s'), findsOneWidget);
         expect(find.text('2.0KB/s'), findsOneWidget);
         expect(find.text('4.0KB/s'), findsOneWidget);
-        // Physical: used 4000 / total 8000, ARC: 1000 / total 8000.
-        expect(find.text('3.9KB / 7.8KB'), findsOneWidget);
-        expect(find.text('1000B / 7.8KB'), findsOneWidget);
+        // Memory segmented bar legend: free = available(4000) - arc(1000)
+        // = 3000, apps = total(8000) - available(4000) = 4000, arc = 1000.
+        expect(find.text('Free'), findsOneWidget);
+        expect(find.text('ZFS ARC'), findsOneWidget);
+        expect(find.text('Apps & Services'), findsOneWidget);
+        expect(find.text('2.9KB'), findsOneWidget);
+        expect(find.text('1000B'), findsOneWidget);
+        expect(find.text('3.9KB'), findsOneWidget);
         // No cores, no network -> neither section renders.
         expect(find.text('Cores'), findsNothing);
         expect(find.text('Network'), findsNothing);


### PR DESCRIPTION
## Summary

- Add a live **Jobs** screen (Running / Waiting / History segments, expandable job detail, Cancel/Retry) backed by a new `JobsProvider` subscribed via TrueNAS's `core.get_jobs`, following the same subscribe/unsubscribe lifecycle as `SystemStatsProvider`.
- Add a `JobsBellButton` to the nav bar of every server-scoped screen (Detail, Pools, Apps, Files, Health). It's blue with a running-job count, shows a steady red dot if idle after a recent failure, and is dim otherwise. Tapping it opens the Jobs screen.
- Replace the Memory card's two-row Physical/ARC breakdown with a single horizontal `MemorySegmentedBar` split into Free / ZFS ARC / Apps & Services, sized so the three segments always sum to 100% of physical memory (Free is `available − arcSize`, since TrueNAS reports ARC as reclaimable/available memory).

### Data layer

- `Job`/`JobProgress` models parsing TrueNAS's `core.get_jobs` job shape (state, progress, timestamps, error, logs excerpt).
- `ApiClientInterface`/`TrueNasApiClient`: `getJobs()`, `subscribeToJobs()`/`unsubscribeFromJobs()` (via `core.subscribe(['core.get_jobs'])`, merging `collection_update` deltas into the live list), `abortJob()` (`core.job_abort`), `rerunJob()` (re-submits a failed job's original method + arguments).
- `MemoryStats` gained `freeMemory`/`appsMemory` (+ percent) getters.

### Scope note

`DatasetDetailScreen` intentionally does **not** get the bell — its existing tests document it as a pure, provider-free display widget, and preserving that felt better than adding a `JobsProvider` dependency two levels deep in the pool → dataset drill-down just for bell coverage.

## Test plan

- [x] `dart format` (clean)
- [x] `flutter analyze` (no issues)
- [x] `flutter test` — 1007/1007 passing, including new coverage for `Job`, `JobsProvider`, `MemoryStats`, and `JobsBellButton` states
- [x] Coverage ratchet: 85.3% vs an 85% floor
- [ ] Manual verification against a real TrueNAS server (not available in this environment) — the job subscription wiring mirrors the existing, already-verified `SystemStatsProvider`/`reporting.realtime` pattern, but hasn't been exercised against a live `core.get_jobs` stream

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01BSgYk6ZDrzGBGgLstiY2sh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSgYk6ZDrzGBGgLstiY2sh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Jobs screen with live running, queued, and historical job status.
  * Added job progress details, cancellation for eligible jobs, and retry for failed jobs.
  * Added navigation indicators showing active job counts and recent failures.
  * Added enhanced memory visualization for Free, ZFS ARC, and Apps & Services.
* **Bug Fixes**
  * Improved memory calculations, including ARC-aware values and zero-total safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->