### PR TITLE
feat: consolidate loading and empty states across screens

### DIFF
--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -41,6 +41,7 @@ class ServerProvider extends ChangeNotifier {
   AuthenticationState _authState = AuthenticationState.none;
   String? _authError;
 
+  bool _isLoadingServers = true;
   ServerHealth? _serverHealth;
   bool _isLoadingHealth = false;
   String? _healthError;
@@ -59,6 +60,7 @@ class ServerProvider extends ChangeNotifier {
     // Listen to server changes from the unified service
     _serversSubscription = _serverService.serversStream.listen((servers) {
       _servers = servers;
+      _isLoadingServers = false;
       notifyListeners();
 
       // Auto-select server if needed
@@ -70,6 +72,7 @@ class ServerProvider extends ChangeNotifier {
   }
 
   List<models.NasServer> get servers => _servers;
+  bool get isLoadingServers => _isLoadingServers;
   models.NasServer? get selectedServer => _selectedServer;
 
   // Stream for authentication state
@@ -102,11 +105,14 @@ class ServerProvider extends ChangeNotifier {
     try {
       _servers = await _serverService.getAllServers();
       if (_disposed) return;
+      _isLoadingServers = false;
       notifyListeners();
     } catch (e) {
       if (kDebugMode) {
         print('ServerProvider: Failed to load servers: $e');
       }
+      _isLoadingServers = false;
+      if (!_disposed) notifyListeners();
     }
   }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:truehub/providers/server_provider.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
+import 'package:truehub/widgets/loading_state_widget.dart';
 import 'package:truehub/widgets/server_list_tile.dart';
 import 'package:truehub/widgets/session_indicator_widget.dart';
 
@@ -105,34 +107,15 @@ class _HomeScreenState extends State<HomeScreen> {
       child: SafeArea(
         child: Consumer<ServerProvider>(
           builder: (context, serverProvider, child) {
+            if (serverProvider.isLoadingServers) {
+              return const LoadingStateWidget(message: 'Loading servers...');
+            }
+
             if (serverProvider.servers.isEmpty) {
-              return const Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      CupertinoIcons.desktopcomputer,
-                      size: 64,
-                      color: CupertinoColors.systemGrey,
-                    ),
-                    SizedBox(height: 16),
-                    Text(
-                      'No servers added yet',
-                      style: TextStyle(
-                        fontSize: 18,
-                        color: CupertinoColors.systemGrey,
-                      ),
-                    ),
-                    SizedBox(height: 8),
-                    Text(
-                      'Tap + to add your first TrueNAS server',
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: CupertinoColors.systemGrey2,
-                      ),
-                    ),
-                  ],
-                ),
+              return const EmptyStateWidget(
+                icon: CupertinoIcons.desktopcomputer,
+                title: 'No servers added yet',
+                message: 'Tap + to add your first TrueNAS server',
               );
             }
 

--- a/lib/screens/pool_detail_screen.dart
+++ b/lib/screens/pool_detail_screen.dart
@@ -3,7 +3,10 @@ import 'package:provider/provider.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/dataset_provider.dart';
 import 'package:truehub/screens/dataset_detail_screen.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
+import 'package:truehub/widgets/error_state_widget.dart';
 import 'package:truehub/widgets/jobs_bell_button.dart';
+import 'package:truehub/widgets/loading_state_widget.dart';
 
 class PoolDetailScreen extends StatefulWidget {
   final NasServer server;
@@ -79,46 +82,16 @@ class _PoolDetailScreenState extends State<PoolDetailScreen> {
               builder: (context, provider, child) {
                 if (provider.isLoading) {
                   return const SliverToBoxAdapter(
-                    child: Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(32),
-                        child: CupertinoActivityIndicator(),
-                      ),
-                    ),
+                    child: LoadingStateWidget(message: 'Loading datasets...'),
                   );
                 }
 
                 if (provider.error != null) {
                   return SliverToBoxAdapter(
-                    child: Center(
-                      child: Padding(
-                        padding: const EdgeInsets.all(32),
-                        child: Column(
-                          children: [
-                            const Icon(
-                              CupertinoIcons.exclamationmark_triangle,
-                              size: 48,
-                              color: CupertinoColors.systemRed,
-                            ),
-                            const SizedBox(height: 16),
-                            const Text('Error loading datasets'),
-                            const SizedBox(height: 8),
-                            Text(
-                              provider.error!,
-                              style: const TextStyle(
-                                color: CupertinoColors.systemGrey,
-                                fontSize: 14,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                            const SizedBox(height: 16),
-                            CupertinoButton(
-                              onPressed: _loadDatasets,
-                              child: const Text('Retry'),
-                            ),
-                          ],
-                        ),
-                      ),
+                    child: ErrorStateWidget(
+                      title: 'Error loading datasets',
+                      message: provider.error!,
+                      onRetry: _loadDatasets,
                     ),
                   );
                 }
@@ -130,21 +103,10 @@ class _PoolDetailScreenState extends State<PoolDetailScreen> {
 
                 if (poolDatasets.isEmpty) {
                   return const SliverToBoxAdapter(
-                    child: Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(32),
-                        child: Column(
-                          children: [
-                            Icon(
-                              CupertinoIcons.folder,
-                              size: 48,
-                              color: CupertinoColors.systemGrey,
-                            ),
-                            SizedBox(height: 16),
-                            Text('No datasets found'),
-                          ],
-                        ),
-                      ),
+                    child: EmptyStateWidget(
+                      icon: CupertinoIcons.folder,
+                      title: 'No datasets found',
+                      message: 'Datasets created in this pool will appear here.',
                     ),
                   );
                 }

--- a/lib/screens/pool_detail_screen.dart
+++ b/lib/screens/pool_detail_screen.dart
@@ -106,7 +106,8 @@ class _PoolDetailScreenState extends State<PoolDetailScreen> {
                     child: EmptyStateWidget(
                       icon: CupertinoIcons.folder,
                       title: 'No datasets found',
-                      message: 'Datasets created in this pool will appear here.',
+                      message:
+                          'Datasets created in this pool will appear here.',
                     ),
                   );
                 }

--- a/lib/screens/server_apps_screen.dart
+++ b/lib/screens/server_apps_screen.dart
@@ -4,7 +4,10 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/models/app.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/widgets/app_card_widget.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
+import 'package:truehub/widgets/error_state_widget.dart';
 import 'package:truehub/widgets/jobs_bell_button.dart';
+import 'package:truehub/widgets/loading_state_widget.dart';
 
 class ServerAppsScreen extends StatefulWidget {
   final NasServer server;
@@ -158,7 +161,7 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
               child: Consumer<AppProvider>(
                 builder: (context, appProvider, child) {
                   if (appProvider.isLoading) {
-                    return const Center(child: CupertinoActivityIndicator());
+                    return const LoadingStateWidget(message: 'Loading apps...');
                   }
 
                   if (appProvider.error != null) {
@@ -237,41 +240,12 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
   }
 
   Widget _buildErrorView(String error) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(
-              CupertinoIcons.exclamationmark_triangle,
-              size: 48,
-              color: CupertinoColors.systemRed,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Failed to load apps',
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              error,
-              style: const TextStyle(
-                fontSize: 14,
-                color: CupertinoColors.systemGrey,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            CupertinoButton.filled(
-              child: const Text('Retry'),
-              onPressed: () {
-                context.read<AppProvider>().refreshApps();
-              },
-            ),
-          ],
-        ),
-      ),
+    return ErrorStateWidget(
+      title: 'Failed to load apps',
+      message: error,
+      onRetry: () {
+        context.read<AppProvider>().refreshApps();
+      },
     );
   }
 
@@ -307,34 +281,10 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
         icon = CupertinoIcons.app;
     }
 
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(icon, size: 48, color: CupertinoColors.systemGrey),
-            const SizedBox(height: 16),
-            Text(
-              title,
-              style: const TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-                color: CupertinoColors.systemGrey,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              _searchQuery.isNotEmpty ? 'No apps match your search' : subtitle,
-              style: const TextStyle(
-                fontSize: 14,
-                color: CupertinoColors.systemGrey2,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-      ),
+    return EmptyStateWidget(
+      icon: icon,
+      title: title,
+      message: _searchQuery.isNotEmpty ? 'No apps match your search' : subtitle,
     );
   }
 }

--- a/lib/screens/server_detail_screen.dart
+++ b/lib/screens/server_detail_screen.dart
@@ -15,6 +15,7 @@ import 'package:truehub/widgets/pool_card_widget.dart';
 import 'package:truehub/widgets/app_card_widget.dart';
 import 'package:truehub/widgets/error_state_widget.dart';
 import 'package:truehub/widgets/empty_state_widget.dart';
+import 'package:truehub/widgets/loading_state_widget.dart';
 import 'package:truehub/widgets/connection_status_widget.dart';
 import 'package:truehub/widgets/jobs_bell_button.dart';
 import 'package:truehub/widgets/section_header.dart';
@@ -254,12 +255,7 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
               ),
               const SizedBox(height: 12),
               if (poolProvider.isLoading)
-                const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(32),
-                    child: CupertinoActivityIndicator(),
-                  ),
-                )
+                const LoadingStateWidget(message: 'Loading pools...')
               else if (poolProvider.error != null)
                 ErrorStateWidget(
                   title: 'Pool Error',
@@ -342,12 +338,7 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
               ),
               const SizedBox(height: 12),
               if (appProvider.isLoading)
-                const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(32),
-                    child: CupertinoActivityIndicator(),
-                  ),
-                )
+                const LoadingStateWidget(message: 'Loading apps...')
               else if (appProvider.error != null)
                 ErrorStateWidget(
                   title: 'App Error',

--- a/lib/screens/server_files_screen.dart
+++ b/lib/screens/server_files_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
 import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class ServerFilesScreen extends StatelessWidget {
@@ -16,34 +17,11 @@ class ServerFilesScreen extends StatelessWidget {
         trailing: JobsBellButton(server: server),
       ),
       child: const SafeArea(
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                CupertinoIcons.folder,
-                size: 64,
-                color: CupertinoColors.systemGrey,
-              ),
-              SizedBox(height: 16),
-              Text(
-                'File browsing coming soon',
-                style: TextStyle(
-                  fontSize: 18,
-                  color: CupertinoColors.systemGrey,
-                ),
-              ),
-              SizedBox(height: 8),
-              Text(
-                'This feature will allow you to browse\nand manage files on your TrueNAS server',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 14,
-                  color: CupertinoColors.systemGrey2,
-                ),
-              ),
-            ],
-          ),
+        child: EmptyStateWidget(
+          icon: CupertinoIcons.folder,
+          title: 'File browsing coming soon',
+          message:
+              'This feature will allow you to browse\nand manage files on your TrueNAS server',
         ),
       ),
     );

--- a/lib/screens/server_health_screen.dart
+++ b/lib/screens/server_health_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:truehub/models/nas_server.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
 import 'package:truehub/widgets/jobs_bell_button.dart';
 
 class ServerHealthScreen extends StatelessWidget {
@@ -16,34 +17,11 @@ class ServerHealthScreen extends StatelessWidget {
         trailing: JobsBellButton(server: server),
       ),
       child: const SafeArea(
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                CupertinoIcons.heart,
-                size: 64,
-                color: CupertinoColors.systemGrey,
-              ),
-              SizedBox(height: 16),
-              Text(
-                'Health monitoring coming soon',
-                style: TextStyle(
-                  fontSize: 18,
-                  color: CupertinoColors.systemGrey,
-                ),
-              ),
-              SizedBox(height: 8),
-              Text(
-                'This feature will show CPU, memory,\ndisk usage, and system temperatures',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 14,
-                  color: CupertinoColors.systemGrey2,
-                ),
-              ),
-            ],
-          ),
+        child: EmptyStateWidget(
+          icon: CupertinoIcons.heart,
+          title: 'Health monitoring coming soon',
+          message:
+              'This feature will show CPU, memory,\ndisk usage, and system temperatures',
         ),
       ),
     );

--- a/lib/screens/server_pools_screen.dart
+++ b/lib/screens/server_pools_screen.dart
@@ -4,7 +4,9 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/pool_provider.dart';
 import 'package:truehub/screens/pool_detail_screen.dart';
 import 'package:truehub/widgets/connection_error_widget.dart';
+import 'package:truehub/widgets/empty_state_widget.dart';
 import 'package:truehub/widgets/jobs_bell_button.dart';
+import 'package:truehub/widgets/loading_state_widget.dart';
 
 class ServerPoolsScreen extends StatefulWidget {
   final NasServer server;
@@ -44,7 +46,7 @@ class _ServerPoolsScreenState extends State<ServerPoolsScreen> {
         child: Consumer<PoolProvider>(
           builder: (context, provider, child) {
             if (provider.isLoading) {
-              return const Center(child: CupertinoActivityIndicator());
+              return const LoadingStateWidget(message: 'Loading pools...');
             }
 
             if (provider.connectionError != null) {
@@ -61,25 +63,10 @@ class _ServerPoolsScreenState extends State<ServerPoolsScreen> {
             }
 
             if (provider.pools.isEmpty) {
-              return const Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      CupertinoIcons.square_stack_3d_down_right,
-                      size: 48,
-                      color: CupertinoColors.systemGrey,
-                    ),
-                    SizedBox(height: 16),
-                    Text(
-                      'No pools found',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
+              return const EmptyStateWidget(
+                icon: CupertinoIcons.square_stack_3d_down_right,
+                title: 'No pools found',
+                message: 'Storage pools configured on this server will appear here.',
               );
             }
 

--- a/lib/screens/server_pools_screen.dart
+++ b/lib/screens/server_pools_screen.dart
@@ -66,7 +66,8 @@ class _ServerPoolsScreenState extends State<ServerPoolsScreen> {
               return const EmptyStateWidget(
                 icon: CupertinoIcons.square_stack_3d_down_right,
                 title: 'No pools found',
-                message: 'Storage pools configured on this server will appear here.',
+                message:
+                    'Storage pools configured on this server will appear here.',
               );
             }
 

--- a/lib/widgets/loading_state_widget.dart
+++ b/lib/widgets/loading_state_widget.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+
+/// A centered activity indicator with an optional label, matching the layout
+/// of [EmptyStateWidget] and [ErrorStateWidget] so screens can swap between
+/// the three loading/empty/error states without a layout jump.
+class LoadingStateWidget extends StatelessWidget {
+  final String? message;
+
+  const LoadingStateWidget({super.key, this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CupertinoActivityIndicator(radius: 14),
+            if (message != null) ...[
+              const SizedBox(height: 16),
+              Text(
+                message!,
+                style: const TextStyle(
+                  fontSize: 14,
+                  color: CupertinoColors.systemGrey,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -388,16 +388,19 @@ void main() {
   });
 
   group('Additional Coverage Tests', () {
-    test('isLoadingServers flips to false once the initial load completes', () async {
-      final freshProvider = ServerProvider(mockServerService);
-      addTearDown(freshProvider.dispose);
+    test(
+      'isLoadingServers flips to false once the initial load completes',
+      () async {
+        final freshProvider = ServerProvider(mockServerService);
+        addTearDown(freshProvider.dispose);
 
-      expect(freshProvider.isLoadingServers, isTrue);
+        expect(freshProvider.isLoadingServers, isTrue);
 
-      await freshProvider.loadServersAndAutoSelect();
+        await freshProvider.loadServersAndAutoSelect();
 
-      expect(freshProvider.isLoadingServers, isFalse);
-    });
+        expect(freshProvider.isLoadingServers, isFalse);
+      },
+    );
 
     test('should handle authentication state changes', () async {
       // Test authentication stream

--- a/test/providers/server_provider_test.dart
+++ b/test/providers/server_provider_test.dart
@@ -388,6 +388,17 @@ void main() {
   });
 
   group('Additional Coverage Tests', () {
+    test('isLoadingServers flips to false once the initial load completes', () async {
+      final freshProvider = ServerProvider(mockServerService);
+      addTearDown(freshProvider.dispose);
+
+      expect(freshProvider.isLoadingServers, isTrue);
+
+      await freshProvider.loadServersAndAutoSelect();
+
+      expect(freshProvider.isLoadingServers, isFalse);
+    });
+
     test('should handle authentication state changes', () async {
       // Test authentication stream
       expect(

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -23,14 +23,24 @@ void main() {
     );
   });
 
+  tearDown(() async {
+    await TestProviders.disposeTestStack(
+      service: unifiedServerService,
+      database: database,
+    );
+  });
+
   testWidgets('shows a loading indicator while servers are being fetched', (
     WidgetTester tester,
   ) async {
     final loadingProvider = _AlwaysLoadingServerProvider(unifiedServerService);
+    addTearDown(loadingProvider.dispose);
 
     await tester.pumpWidget(
       MultiProvider(
-        providers: [ChangeNotifierProvider.value(value: loadingProvider)],
+        providers: [
+          ChangeNotifierProvider<ServerProvider>.value(value: loadingProvider),
+        ],
         child: const CupertinoApp(home: HomeScreen()),
       ),
     );
@@ -38,22 +48,19 @@ void main() {
 
     expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
     expect(find.text('No servers added yet'), findsNothing);
-
-    await TestProviders.disposeTestStack(
-      providers: [loadingProvider],
-      service: unifiedServerService,
-      database: database,
-    );
   });
 
   testWidgets('shows the empty state once loading finishes with no servers', (
     WidgetTester tester,
   ) async {
     final serverProvider = ServerProvider(unifiedServerService);
+    addTearDown(serverProvider.dispose);
 
     await tester.pumpWidget(
       MultiProvider(
-        providers: [ChangeNotifierProvider.value(value: serverProvider)],
+        providers: [
+          ChangeNotifierProvider<ServerProvider>.value(value: serverProvider),
+        ],
         child: const CupertinoApp(home: HomeScreen()),
       ),
     );
@@ -65,12 +72,6 @@ void main() {
     expect(find.text('No servers added yet'), findsOneWidget);
     expect(find.text('Tap + to add your first TrueNAS server'), findsOneWidget);
     expect(find.byType(CupertinoActivityIndicator), findsNothing);
-
-    await TestProviders.disposeTestStack(
-      providers: [serverProvider],
-      service: unifiedServerService,
-      database: database,
-    );
   });
 }
 

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -1,0 +1,85 @@
+import 'package:drift/native.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:truehub/providers/server_provider.dart';
+import 'package:truehub/screens/home_screen.dart';
+import 'package:truehub/services/database.dart';
+import 'package:truehub/services/unified_server_service.dart';
+import '../helpers/pump_helpers.dart';
+import '../helpers/test_providers.dart';
+
+/// Coverage for ticket: proper loading and empty states on HomeScreen.
+void main() {
+  late AppDatabase database;
+  late UnifiedServerService unifiedServerService;
+
+  setUp(() async {
+    await TestProviders.cleanupTestEnvironment();
+    TestProviders.setupTestEnvironment();
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    unifiedServerService = await TestProviders.createMockUnifiedServerService(
+      database: database,
+    );
+  });
+
+  testWidgets('shows a loading indicator while servers are being fetched', (
+    WidgetTester tester,
+  ) async {
+    final loadingProvider = _AlwaysLoadingServerProvider(unifiedServerService);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [ChangeNotifierProvider.value(value: loadingProvider)],
+        child: const CupertinoApp(home: HomeScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    expect(find.text('No servers added yet'), findsNothing);
+
+    await TestProviders.disposeTestStack(
+      providers: [loadingProvider],
+      service: unifiedServerService,
+      database: database,
+    );
+  });
+
+  testWidgets('shows the empty state once loading finishes with no servers', (
+    WidgetTester tester,
+  ) async {
+    final serverProvider = ServerProvider(unifiedServerService);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [ChangeNotifierProvider.value(value: serverProvider)],
+        child: const CupertinoApp(home: HomeScreen()),
+      ),
+    );
+    await pumpUntilAsync(
+      tester,
+      () => find.text('No servers added yet').evaluate().isNotEmpty,
+    );
+
+    expect(find.text('No servers added yet'), findsOneWidget);
+    expect(find.text('Tap + to add your first TrueNAS server'), findsOneWidget);
+    expect(find.byType(CupertinoActivityIndicator), findsNothing);
+
+    await TestProviders.disposeTestStack(
+      providers: [serverProvider],
+      service: unifiedServerService,
+      database: database,
+    );
+  });
+}
+
+/// A [ServerProvider] whose [isLoadingServers] is pinned to `true`, so a
+/// widget test can render `HomeScreen`'s loading branch deterministically
+/// instead of racing the real async server load.
+class _AlwaysLoadingServerProvider extends ServerProvider {
+  _AlwaysLoadingServerProvider(super.service);
+
+  @override
+  bool get isLoadingServers => true;
+}

--- a/test/widgets/loading_state_widget_test.dart
+++ b/test/widgets/loading_state_widget_test.dart
@@ -7,17 +7,13 @@ void main() {
     testWidgets('shows an activity indicator with no message by default', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(
-        const CupertinoApp(home: LoadingStateWidget()),
-      );
+      await tester.pumpWidget(const CupertinoApp(home: LoadingStateWidget()));
 
       expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
       expect(find.byType(Text), findsNothing);
     });
 
-    testWidgets('shows the message when provided', (
-      WidgetTester tester,
-    ) async {
+    testWidgets('shows the message when provided', (WidgetTester tester) async {
       await tester.pumpWidget(
         const CupertinoApp(
           home: LoadingStateWidget(message: 'Loading pools...'),

--- a/test/widgets/loading_state_widget_test.dart
+++ b/test/widgets/loading_state_widget_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/widgets/loading_state_widget.dart';
+
+void main() {
+  group('LoadingStateWidget', () {
+    testWidgets('shows an activity indicator with no message by default', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const CupertinoApp(home: LoadingStateWidget()),
+      );
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('shows the message when provided', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const CupertinoApp(
+          home: LoadingStateWidget(message: 'Loading pools...'),
+        ),
+      );
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+      expect(find.text('Loading pools...'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a shared `LoadingStateWidget` so screens show a consistent loading indicator instead of hand-rolled `Center(child: CupertinoActivityIndicator())` wrappers.
- Retrofit `HomeScreen`, `ServerPoolsScreen`, `PoolDetailScreen`, `ServerAppsScreen`, `ServerDetailScreen`, `ServerFilesScreen`, and `ServerHealthScreen` to reuse the existing `EmptyStateWidget`/`ErrorStateWidget`/`LoadingStateWidget` instead of duplicating that UI inline.
- `HomeScreen` previously jumped straight from a blank screen to the "No servers" empty state while the server list loaded. `ServerProvider` now exposes `isLoadingServers` so the screen can tell "still loading" apart from "loaded, but genuinely empty".

## Test plan
- [x] Added `test/widgets/loading_state_widget_test.dart` for the new shared widget
- [x] Added `test/screens/home_screen_test.dart` covering the loading and empty branches
- [x] Added a unit test for `ServerProvider.isLoadingServers`'s transition to `false`
- [x] Verified the text/icon finders in existing `server_pools_screen_test.dart` and `pool_detail_screen_test.dart` still match after the refactor
- [ ] `dart format` / `flutter test` (Flutter SDK not available in this environment — please run in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_019sZxk7V5iEsJgydBon6XpT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent loading indicators and messages across server, pool, app, dataset, and detail screens.
  * Added reusable empty and error states with preserved retry actions and contextual messaging.
  * Added clear placeholder states for files and server health views.
  * Server loading status is now tracked for more responsive screen feedback.

* **Bug Fixes**
  * Loading and empty states now update correctly after server loading succeeds or fails.

* **Tests**
  * Added coverage for server loading status, home-screen states, and reusable loading widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->