### PR TITLE
feat: integrate flutter_otel OpenTelemetry SDK for logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,17 +96,25 @@ jobs:
 
     - name: Build iOS (no codesign)
       # OTLP_INGEST_URL/OTLP_INGEST_KEY may not be set as repo secrets yet -
-      # GitHub Actions substitutes an empty string for a missing secret,
-      # which leaves OTEL_EXPORTER_OTLP_ENDPOINT empty and telemetry disabled
+      # GitHub Actions substitutes an empty string for a missing secret. Both
+      # must be non-blank for telemetry to turn on: an endpoint with no key
+      # would otherwise compose an empty bearer token, which is worse than
+      # just leaving OTEL_EXPORTER_OTLP_ENDPOINT unset and telemetry disabled
       # for this build (TelemetryConfig.enabled), not the build failing.
       env:
         OTLP_INGEST_URL: ${{ secrets.OTLP_INGEST_URL }}
         OTLP_INGEST_KEY: ${{ secrets.OTLP_INGEST_KEY }}
       run: |
-        flutter build ios --no-codesign \
-          --dart-define=OTEL_EXPORTER_OTLP_ENDPOINT="$OTLP_INGEST_URL" \
-          --dart-define=OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer $OTLP_INGEST_KEY,x-tenant-id=homelab,x-dataset-id=apps" \
-          --dart-define=OTEL_SERVICE_NAME=truehub
+        DART_DEFINES=()
+        if [ -n "$OTLP_INGEST_URL" ] && [ -n "$OTLP_INGEST_KEY" ]; then
+          DART_DEFINES+=(
+            --dart-define=OTEL_EXPORTER_OTLP_ENDPOINT="$OTLP_INGEST_URL"
+            --dart-define=OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer $OTLP_INGEST_KEY,x-tenant-id=homelab,x-dataset-id=apps"
+            --dart-define=OTEL_SERVICE_NAME=truehub
+            --dart-define=OTEL_DEPLOYMENT_ENVIRONMENT=production
+          )
+        fi
+        flutter build ios --no-codesign "${DART_DEFINES[@]}"
 
     # `flutter build macos` has no --no-codesign flag, and the runner has no
     # signing identity, so the Release configuration's Manual signing fails
@@ -121,7 +129,13 @@ jobs:
         OTLP_INGEST_URL: ${{ secrets.OTLP_INGEST_URL }}
         OTLP_INGEST_KEY: ${{ secrets.OTLP_INGEST_KEY }}
       run: |
-        flutter build macos \
-          --dart-define=OTEL_EXPORTER_OTLP_ENDPOINT="$OTLP_INGEST_URL" \
-          --dart-define=OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer $OTLP_INGEST_KEY,x-tenant-id=homelab,x-dataset-id=apps" \
-          --dart-define=OTEL_SERVICE_NAME=truehub
+        DART_DEFINES=()
+        if [ -n "$OTLP_INGEST_URL" ] && [ -n "$OTLP_INGEST_KEY" ]; then
+          DART_DEFINES+=(
+            --dart-define=OTEL_EXPORTER_OTLP_ENDPOINT="$OTLP_INGEST_URL"
+            --dart-define=OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer $OTLP_INGEST_KEY,x-tenant-id=homelab,x-dataset-id=apps"
+            --dart-define=OTEL_SERVICE_NAME=truehub
+            --dart-define=OTEL_DEPLOYMENT_ENVIRONMENT=production
+          )
+        fi
+        flutter build macos "${DART_DEFINES[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,18 @@ jobs:
       run: ruby fastlane/test/pubspec_version_test.rb
 
     - name: Build iOS (no codesign)
-      run: flutter build ios --no-codesign
+      # OTLP_INGEST_URL/OTLP_INGEST_KEY may not be set as repo secrets yet -
+      # GitHub Actions substitutes an empty string for a missing secret,
+      # which leaves OTEL_EXPORTER_OTLP_ENDPOINT empty and telemetry disabled
+      # for this build (TelemetryConfig.enabled), not the build failing.
+      env:
+        OTLP_INGEST_URL: ${{ secrets.OTLP_INGEST_URL }}
+        OTLP_INGEST_KEY: ${{ secrets.OTLP_INGEST_KEY }}
+      run: |
+        flutter build ios --no-codesign \
+          --dart-define=OTEL_EXPORTER_OTLP_ENDPOINT="$OTLP_INGEST_URL" \
+          --dart-define=OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer $OTLP_INGEST_KEY,x-tenant-id=homelab,x-dataset-id=apps" \
+          --dart-define=OTEL_SERVICE_NAME=truehub
 
     # `flutter build macos` has no --no-codesign flag, and the runner has no
     # signing identity, so the Release configuration's Manual signing fails
@@ -107,4 +118,10 @@ jobs:
         FLUTTER_XCODE_CODE_SIGNING_ALLOWED: "NO"
         FLUTTER_XCODE_CODE_SIGNING_REQUIRED: "NO"
         FLUTTER_XCODE_CODE_SIGN_IDENTITY: ""
-      run: flutter build macos
+        OTLP_INGEST_URL: ${{ secrets.OTLP_INGEST_URL }}
+        OTLP_INGEST_KEY: ${{ secrets.OTLP_INGEST_KEY }}
+      run: |
+        flutter build macos \
+          --dart-define=OTEL_EXPORTER_OTLP_ENDPOINT="$OTLP_INGEST_URL" \
+          --dart-define=OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer $OTLP_INGEST_KEY,x-tenant-id=homelab,x-dataset-id=apps" \
+          --dart-define=OTEL_SERVICE_NAME=truehub

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -23,3 +23,8 @@
 
 # MATCH_GIT_URL=git@github.com:cedricziel/certificates.git
 # MATCH_PASSWORD=
+
+# SignalDB OTLP ingest, used to build the flutter_otel --dart-define flags in
+# the build_ios lane. Blank/unset leaves telemetry disabled for the build.
+# OTLP_INGEST_URL=
+# OTLP_INGEST_KEY=

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -134,7 +134,9 @@ end
 # OTLP_INGEST_URL / OTLP_INGEST_KEY (fastlane already loads fastlane/.env via
 # Dotenv locally, and CI secrets are exported as env vars). Either being
 # missing/blank just leaves telemetry disabled for this build
-# (TelemetryConfig.enabled) - it never fails the build.
+# (TelemetryConfig.enabled) - it never fails the build. Both must be present
+# for telemetry to turn on: an endpoint with no key would otherwise compose
+# an empty bearer token, which is worse than just staying disabled.
 def telemetry_dart_defines
   # fastlane auto-loads fastlane/.env.default, whose placeholder entries
   # yield empty strings - treat those as unset, same helper pattern as
@@ -146,14 +148,15 @@ def telemetry_dart_defines
   endpoint = env.call("OTLP_INGEST_URL")
   api_key  = env.call("OTLP_INGEST_KEY")
 
-  return [] if endpoint.nil?
+  return [] if endpoint.nil? || api_key.nil?
 
   headers = "authorization=Bearer #{api_key},x-tenant-id=homelab,x-dataset-id=apps"
 
   [
     "--dart-define=OTEL_EXPORTER_OTLP_ENDPOINT=#{endpoint}",
     "--dart-define=OTEL_EXPORTER_OTLP_HEADERS=#{headers}",
-    "--dart-define=OTEL_SERVICE_NAME=truehub"
+    "--dart-define=OTEL_SERVICE_NAME=truehub",
+    "--dart-define=OTEL_DEPLOYMENT_ENVIRONMENT=production"
   ]
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,12 +97,15 @@ private_lane :build_ios do
   # the Xcode project reads as MARKETING_VERSION / CURRENT_PROJECT_VERSION.
   # with_unbundled_env: flutter shells out to CocoaPods, which must resolve
   # against the system gems, not this bundle (where cocoapods isn't a dep).
+  dart_defines = telemetry_dart_defines
+
   Dir.chdir("..") do
     Bundler.with_unbundled_env do
       sh(
         "flutter", "build", "ios", "--release", "--no-codesign",
         "--build-name=#{marketing_version}",
-        "--build-number=#{commit_count_build_number}"
+        "--build-number=#{commit_count_build_number}",
+        *dart_defines
       )
     end
   end
@@ -125,6 +128,33 @@ private_lane :build_ios do
   api_key
 ensure
   File.binwrite(pbxproj, pbxproj_original) if pbxproj_original
+end
+
+# Builds the `--dart-define` flags that wire flutter_otel to SignalDB, from
+# OTLP_INGEST_URL / OTLP_INGEST_KEY (fastlane already loads fastlane/.env via
+# Dotenv locally, and CI secrets are exported as env vars). Either being
+# missing/blank just leaves telemetry disabled for this build
+# (TelemetryConfig.enabled) - it never fails the build.
+def telemetry_dart_defines
+  # fastlane auto-loads fastlane/.env.default, whose placeholder entries
+  # yield empty strings - treat those as unset, same helper pattern as
+  # load_app_store_connect_api_key below.
+  env = ->(name) {
+    value = ENV[name]
+    value.nil? || value.strip.empty? ? nil : value
+  }
+  endpoint = env.call("OTLP_INGEST_URL")
+  api_key  = env.call("OTLP_INGEST_KEY")
+
+  return [] if endpoint.nil?
+
+  headers = "authorization=Bearer #{api_key},x-tenant-id=homelab,x-dataset-id=apps"
+
+  [
+    "--dart-define=OTEL_EXPORTER_OTLP_ENDPOINT=#{endpoint}",
+    "--dart-define=OTEL_EXPORTER_OTLP_HEADERS=#{headers}",
+    "--dart-define=OTEL_SERVICE_NAME=truehub"
+  ]
 end
 
 # Loads an App Store Connect API key from one of:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,10 +18,15 @@ import 'package:truehub/services/database.dart';
 import 'package:truehub/services/api_client_manager.dart';
 import 'package:truehub/services/window_manager.dart';
 import 'package:truehub/services/unified_server_service.dart';
+import 'package:truehub/services/telemetry_config.dart';
+import 'package:truehub/services/telemetry_service.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
 import 'package:truehub/models/app_config.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final telemetryService = await _bootstrapTelemetry();
 
   final database = AppDatabase.instance;
   final connectionStatusProvider = ConnectionStatusProvider();
@@ -33,6 +38,7 @@ void main() async {
   runApp(
     MultiProvider(
       providers: [
+        Provider<TelemetryServiceInterface>.value(value: telemetryService),
         Provider<AppDatabase>.value(value: database),
         Provider<UnifiedServerService>.value(value: unifiedServerService),
         ChangeNotifierProvider.value(value: connectionStatusProvider),
@@ -62,6 +68,44 @@ void main() async {
       child: const TrueNASManagerApp(),
     ),
   );
+}
+
+/// Initializes telemetry from build-time config and wires uncaught Flutter
+/// framework errors and uncaught platform/async errors through to it, so
+/// crashes and unhandled exceptions turn into OTel log records automatically
+/// without every call site needing to know telemetry exists.
+///
+/// Always returns a usable [TelemetryServiceInterface] - when
+/// [TelemetryConfig.enabled] is `false` (no OTLP endpoint configured), the
+/// underlying SDK is initialized in its own no-op mode rather than skipped,
+/// so callers elsewhere in the app never need a null check.
+Future<TelemetryServiceInterface> _bootstrapTelemetry() async {
+  final telemetryService = await TelemetryService.initialize(
+    TelemetryConfig.fromEnvironment(),
+  );
+
+  final previousOnError = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    telemetryService.recordError(
+      details.exception,
+      details.stack ?? StackTrace.current,
+      context: 'FlutterError.onError',
+    );
+    previousOnError?.call(details);
+  };
+
+  final previousPlatformOnError = PlatformDispatcher.instance.onError;
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    telemetryService.recordError(
+      error,
+      stack,
+      context: 'PlatformDispatcher.instance.onError',
+      fatal: true,
+    );
+    return previousPlatformOnError?.call(error, stack) ?? false;
+  };
+
+  return telemetryService;
 }
 
 class TrueNASManagerApp extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,15 +18,14 @@ import 'package:truehub/services/database.dart';
 import 'package:truehub/services/api_client_manager.dart';
 import 'package:truehub/services/window_manager.dart';
 import 'package:truehub/services/unified_server_service.dart';
-import 'package:truehub/services/telemetry_config.dart';
-import 'package:truehub/services/telemetry_service.dart';
 import 'package:truehub/services/telemetry_service_interface.dart';
+import 'package:truehub/services/telemetry_bootstrap.dart';
 import 'package:truehub/models/app_config.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  final telemetryService = await _bootstrapTelemetry();
+  final telemetryService = await bootstrapTelemetry();
 
   final database = AppDatabase.instance;
   final connectionStatusProvider = ConnectionStatusProvider();
@@ -68,44 +67,6 @@ void main() async {
       child: const TrueNASManagerApp(),
     ),
   );
-}
-
-/// Initializes telemetry from build-time config and wires uncaught Flutter
-/// framework errors and uncaught platform/async errors through to it, so
-/// crashes and unhandled exceptions turn into OTel log records automatically
-/// without every call site needing to know telemetry exists.
-///
-/// Always returns a usable [TelemetryServiceInterface] - when
-/// [TelemetryConfig.enabled] is `false` (no OTLP endpoint configured), the
-/// underlying SDK is initialized in its own no-op mode rather than skipped,
-/// so callers elsewhere in the app never need a null check.
-Future<TelemetryServiceInterface> _bootstrapTelemetry() async {
-  final telemetryService = await TelemetryService.initialize(
-    TelemetryConfig.fromEnvironment(),
-  );
-
-  final previousOnError = FlutterError.onError;
-  FlutterError.onError = (FlutterErrorDetails details) {
-    telemetryService.recordError(
-      details.exception,
-      details.stack ?? StackTrace.current,
-      context: 'FlutterError.onError',
-    );
-    previousOnError?.call(details);
-  };
-
-  final previousPlatformOnError = PlatformDispatcher.instance.onError;
-  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
-    telemetryService.recordError(
-      error,
-      stack,
-      context: 'PlatformDispatcher.instance.onError',
-      fatal: true,
-    );
-    return previousPlatformOnError?.call(error, stack) ?? false;
-  };
-
-  return telemetryService;
 }
 
 class TrueNASManagerApp extends StatefulWidget {

--- a/lib/services/telemetry_bootstrap.dart
+++ b/lib/services/telemetry_bootstrap.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:truehub/services/telemetry_config.dart';
+import 'package:truehub/services/telemetry_service.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
+
+/// Initializes telemetry from build-time config and wires uncaught Flutter
+/// framework errors and uncaught platform/async errors through to it, so
+/// crashes and unhandled exceptions turn into OTel log records automatically
+/// without every call site needing to know telemetry exists.
+///
+/// Always returns a usable [TelemetryServiceInterface] - when
+/// [TelemetryConfig.enabled] is `false` (no OTLP endpoint configured), the
+/// underlying SDK is initialized in its own no-op mode rather than skipped,
+/// so callers elsewhere in the app never need a null check.
+///
+/// [config] and [initializeService] are injectable so tests can exercise the
+/// error-handler wiring below without a real [TelemetryConfig.fromEnvironment]
+/// / [TelemetryService.initialize] round trip.
+Future<TelemetryServiceInterface> bootstrapTelemetry({
+  TelemetryConfig? config,
+  Future<TelemetryServiceInterface> Function(TelemetryConfig)?
+  initializeService,
+}) async {
+  final telemetryService =
+      await (initializeService ?? TelemetryService.initialize)(
+        config ?? TelemetryConfig.fromEnvironment(),
+      );
+
+  final previousOnError = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    telemetryService.recordError(
+      details.exception,
+      details.stack ?? StackTrace.current,
+      context: 'FlutterError.onError',
+    );
+    previousOnError?.call(details);
+  };
+
+  final previousPlatformOnError = PlatformDispatcher.instance.onError;
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    telemetryService.recordError(
+      error,
+      stack,
+      context: 'PlatformDispatcher.instance.onError',
+      fatal: true,
+    );
+    // Per Flutter's own docs, the VM/process may exit or become
+    // unresponsive once this callback returns, so buffered telemetry must be
+    // flushed explicitly here rather than relying on a graceful shutdown
+    // path that may never run.
+    unawaited(telemetryService.flush());
+    return previousPlatformOnError?.call(error, stack) ?? false;
+  };
+
+  return telemetryService;
+}

--- a/lib/services/telemetry_config.dart
+++ b/lib/services/telemetry_config.dart
@@ -1,0 +1,90 @@
+/// Build-time telemetry configuration, read from `--dart-define` values at
+/// compile time (see the `--dart-define` flags added in
+/// `.github/workflows/ci.yml` and `fastlane/Fastfile`).
+///
+/// Telemetry is enabled solely by [otlpEndpoint] being non-empty - there is
+/// no separate on/off flag. This keeps a single source of truth: set the
+/// endpoint to turn telemetry on, leave it unset (the default) to turn it
+/// off, everywhere including local `flutter run` with no `--dart-define`s
+/// at all.
+class TelemetryConfig {
+  const TelemetryConfig({
+    required this.otlpEndpoint,
+    required this.otlpHeaders,
+    required this.serviceName,
+    required this.deploymentEnvironment,
+  });
+
+  /// Reads the configuration compiled into this build via `--dart-define`.
+  factory TelemetryConfig.fromEnvironment() => TelemetryConfig(
+    otlpEndpoint: _otlpEndpointRaw,
+    otlpHeaders: parseHeaders(_otlpHeadersRaw),
+    serviceName: _serviceName,
+    deploymentEnvironment: _deploymentEnvironment,
+  );
+
+  // `String.fromEnvironment` only accepts compile-time-constant arguments,
+  // so the dart-define names are read once here rather than inlined in
+  // `fromEnvironment` above - keeps the env var names in exactly one place.
+  static const String _otlpEndpointRaw = String.fromEnvironment(
+    'OTEL_EXPORTER_OTLP_ENDPOINT',
+    defaultValue: '',
+  );
+  static const String _otlpHeadersRaw = String.fromEnvironment(
+    'OTEL_EXPORTER_OTLP_HEADERS',
+    defaultValue: '',
+  );
+  static const String _serviceName = String.fromEnvironment(
+    'OTEL_SERVICE_NAME',
+    defaultValue: 'truehub',
+  );
+  static const String _deploymentEnvironment = String.fromEnvironment(
+    'OTEL_DEPLOYMENT_ENVIRONMENT',
+    defaultValue: 'development',
+  );
+
+  /// SignalDB OTLP ingest base URL. Empty (the default) means telemetry is
+  /// disabled - see [enabled].
+  final String otlpEndpoint;
+
+  /// Extra headers sent with every OTLP export request, parsed from the
+  /// standard `OTEL_EXPORTER_OTLP_HEADERS` comma-separated `key=value`
+  /// format via [parseHeaders].
+  final Map<String, String> otlpHeaders;
+
+  /// `service.name` resource attribute.
+  final String serviceName;
+
+  /// `deployment.environment` resource attribute.
+  final String deploymentEnvironment;
+
+  /// Telemetry is enabled if and only if [otlpEndpoint] is non-empty.
+  bool get enabled => otlpEndpoint.isNotEmpty;
+
+  /// Parses the standard `OTEL_EXPORTER_OTLP_HEADERS` env var format:
+  /// comma-separated `key=value` pairs, e.g.
+  /// `x-api-key=secret,x-tenant=homelab`.
+  ///
+  /// Splits on `,` first, then on the *first* `=` in each pair, so values
+  /// are free to contain `=` themselves (e.g. base64). Blank entries, and
+  /// entries with no `=` or an empty key, are skipped rather than throwing -
+  /// this parses build-time configuration, not user input worth failing
+  /// loudly over.
+  static Map<String, String> parseHeaders(String raw) {
+    final headers = <String, String>{};
+    for (final pair in raw.split(',')) {
+      final trimmedPair = pair.trim();
+      if (trimmedPair.isEmpty) continue;
+
+      final separatorIndex = trimmedPair.indexOf('=');
+      if (separatorIndex <= 0) continue;
+
+      final key = trimmedPair.substring(0, separatorIndex).trim();
+      final value = trimmedPair.substring(separatorIndex + 1).trim();
+      if (key.isEmpty) continue;
+
+      headers[key] = value;
+    }
+    return headers;
+  }
+}

--- a/lib/services/telemetry_service.dart
+++ b/lib/services/telemetry_service.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_otel/flutter_otel.dart';
+import 'package:truehub/services/telemetry_config.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
+
+/// Default [TelemetryServiceInterface] implementation, wrapping [OTelSdk].
+///
+/// [initialize] always sets up the SDK, even when [TelemetryConfig.enabled]
+/// is `false` - it just passes that through as [OTelSdkConfig.enabled],
+/// which makes the SDK wire up a no-op exporter internally. The rest of the
+/// app therefore never needs to null-check a "telemetry might not exist"
+/// case: logging calls always succeed, they just go nowhere when disabled.
+class TelemetryService implements TelemetryServiceInterface {
+  TelemetryService._(this._sdk);
+
+  final OTelSdk _sdk;
+
+  /// Initializes the underlying [OTelSdk] from [config] and returns a
+  /// service wrapping it.
+  static Future<TelemetryService> initialize(TelemetryConfig config) async {
+    final sdk = await OTelSdk.initialize(
+      OTelSdkConfig(
+        resource: OTelResource(
+          serviceName: config.serviceName,
+          deploymentEnvironment: config.deploymentEnvironment,
+        ),
+        enabled: config.enabled,
+        otlpEndpoint: config.enabled ? Uri.parse(config.otlpEndpoint) : null,
+        otlpHeaders: config.otlpHeaders,
+      ),
+    );
+    return TelemetryService._(sdk);
+  }
+
+  @override
+  Logger getLogger({String name = 'truehub', String? version}) =>
+      _sdk.getLogger(name: name, version: version);
+
+  @override
+  void recordError(
+    Object error,
+    StackTrace stackTrace, {
+    String? context,
+    bool fatal = false,
+  }) {
+    final logger = getLogger();
+    final body = context == null ? error.toString() : '$context: $error';
+
+    if (fatal) {
+      logger.emit(
+        LogRecord(
+          body: body,
+          severity: LogSeverity.fatal,
+          attributes: {
+            'exception.type': error.runtimeType.toString(),
+            'exception.message': error.toString(),
+            'exception.stacktrace': stackTrace.toString(),
+          },
+        ),
+      );
+    } else {
+      logger.error(body, error: error, stackTrace: stackTrace);
+    }
+  }
+
+  @override
+  Future<void> flush() => _sdk.forceFlush();
+
+  @override
+  Future<void> shutdown() => _sdk.shutdown();
+}

--- a/lib/services/telemetry_service.dart
+++ b/lib/services/telemetry_service.dart
@@ -16,15 +16,25 @@ class TelemetryService implements TelemetryServiceInterface {
 
   /// Initializes the underlying [OTelSdk] from [config] and returns a
   /// service wrapping it.
+  ///
+  /// [config.otlpEndpoint] is a build-time string (see [TelemetryConfig])
+  /// that could be malformed - e.g. a misconfigured CI secret. Parsing it
+  /// with [Uri.tryParse] instead of [Uri.parse] means a bad value falls back
+  /// to the same disabled/no-op SDK path used when no endpoint is configured
+  /// at all, rather than throwing a [FormatException] that would crash the
+  /// app on startup before the UI ever renders (`main()` awaits this before
+  /// `runApp`).
   static Future<TelemetryService> initialize(TelemetryConfig config) async {
+    final endpoint = config.enabled ? Uri.tryParse(config.otlpEndpoint) : null;
+
     final sdk = await OTelSdk.initialize(
       OTelSdkConfig(
         resource: OTelResource(
           serviceName: config.serviceName,
           deploymentEnvironment: config.deploymentEnvironment,
         ),
-        enabled: config.enabled,
-        otlpEndpoint: config.enabled ? Uri.parse(config.otlpEndpoint) : null,
+        enabled: config.enabled && endpoint != null,
+        otlpEndpoint: endpoint,
         otlpHeaders: config.otlpHeaders,
       ),
     );

--- a/lib/services/telemetry_service_interface.dart
+++ b/lib/services/telemetry_service_interface.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_otel/flutter_otel.dart';
+
+/// Abstraction over the telemetry SDK so the rest of the app codes against
+/// an interface rather than `package:flutter_otel` directly (per this
+/// repo's interfaces + dependency-injection philosophy) - real usage is
+/// [TelemetryService], tests can fake this instead of the SDK.
+abstract class TelemetryServiceInterface {
+  /// Returns a [Logger] for the given instrumentation scope. Implementations
+  /// typically cache and return the same instance for a given
+  /// name/version pair.
+  Logger getLogger({String name = 'truehub', String? version});
+
+  /// Records an error and its stack trace as a log record - the intended
+  /// target for `FlutterError.onError` / `PlatformDispatcher.instance.onError`
+  /// hooks, and for any `catch` block that wants a caught error to surface
+  /// in telemetry.
+  ///
+  /// [context] is an optional human-readable note on where the error was
+  /// caught (e.g. `'FlutterError.onError'`), prepended to the log body.
+  /// [fatal] marks the record FATAL severity instead of ERROR - use it for
+  /// errors the app cannot recover from.
+  void recordError(
+    Object error,
+    StackTrace stackTrace, {
+    String? context,
+    bool fatal = false,
+  });
+
+  /// Forces any buffered telemetry to be exported now.
+  Future<void> flush();
+
+  /// Flushes and releases the underlying SDK resources. After this
+  /// resolves, this service should no longer be used.
+  Future<void> shutdown();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -343,8 +343,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/flutter_otel"
-      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
-      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      ref: main
+      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"
@@ -352,8 +352,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/flutter_otel_api"
-      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
-      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      ref: main
+      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"
@@ -361,8 +361,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/flutter_otel_exporter_otlp_http"
-      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
-      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      ref: main
+      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"
@@ -370,8 +370,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/flutter_otel_sdk"
-      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
-      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      ref: main
+      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -339,6 +339,42 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_otel:
+    dependency: "direct main"
+    description:
+      path: "packages/flutter_otel"
+      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
+      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      url: "https://github.com/cedricziel/flutter-otel.git"
+    source: git
+    version: "0.1.0"
+  flutter_otel_api:
+    dependency: "direct overridden"
+    description:
+      path: "packages/flutter_otel_api"
+      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
+      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      url: "https://github.com/cedricziel/flutter-otel.git"
+    source: git
+    version: "0.1.0"
+  flutter_otel_exporter_otlp_http:
+    dependency: "direct overridden"
+    description:
+      path: "packages/flutter_otel_exporter_otlp_http"
+      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
+      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      url: "https://github.com/cedricziel/flutter-otel.git"
+    source: git
+    version: "0.1.0"
+  flutter_otel_sdk:
+    dependency: "direct overridden"
+    description:
+      path: "packages/flutter_otel_sdk"
+      ref: "claude/flutter-otel-sdk-bootstrap-vezelb"
+      resolved-ref: aa4f52ed3bfd47a962e88cc6d7988eed5664298a
+      url: "https://github.com/cedricziel/flutter-otel.git"
+    source: git
+    version: "0.1.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -461,6 +497,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,7 @@ dependencies:
   flutter_otel:
     git:
       url: https://github.com/cedricziel/flutter-otel.git
-      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      ref: main
       path: packages/flutter_otel
 
 dev_dependencies:
@@ -170,17 +170,17 @@ dependency_overrides:
   flutter_otel_api:
     git:
       url: https://github.com/cedricziel/flutter-otel.git
-      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      ref: main
       path: packages/flutter_otel_api
   flutter_otel_sdk:
     git:
       url: https://github.com/cedricziel/flutter-otel.git
-      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      ref: main
       path: packages/flutter_otel_sdk
   flutter_otel_exporter_otlp_http:
     git:
       url: https://github.com/cedricziel/flutter-otel.git
-      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      ref: main
       path: packages/flutter_otel_exporter_otlp_http
 
 dart_pre_commit:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,16 @@ dependencies:
   truenas_native_plugins:
     path: packages/truenas_native_plugins
 
+  # OpenTelemetry SDK (logs signal). Pinned to a branch ref because
+  # flutter-otel isn't merged/published yet - remove the ref pin above and
+  # the dependency_overrides below, and pick a real published version, once
+  # it lands on `main` or pub.dev.
+  flutter_otel:
+    git:
+      url: https://github.com/cedricziel/flutter-otel.git
+      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      path: packages/flutter_otel
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -149,6 +159,29 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
+
+# flutter_otel's own pubspec.yaml declares these three siblings as plain
+# `^0.1.0` version constraints, which only resolve automatically inside the
+# flutter-otel Dart workspace itself. trueapp is a separate workspace, so
+# without these overrides pub tries (and fails) to find them on pub.dev.
+# Pin all four to the same repo/ref/path as the `flutter_otel` dependency
+# above, and drop this block in the same cleanup mentioned there.
+dependency_overrides:
+  flutter_otel_api:
+    git:
+      url: https://github.com/cedricziel/flutter-otel.git
+      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      path: packages/flutter_otel_api
+  flutter_otel_sdk:
+    git:
+      url: https://github.com/cedricziel/flutter-otel.git
+      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      path: packages/flutter_otel_sdk
+  flutter_otel_exporter_otlp_http:
+    git:
+      url: https://github.com/cedricziel/flutter-otel.git
+      ref: claude/flutter-otel-sdk-bootstrap-vezelb
+      path: packages/flutter_otel_exporter_otlp_http
 
 dart_pre_commit:
   format: true

--- a/test/helpers/fake_telemetry_service.dart
+++ b/test/helpers/fake_telemetry_service.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_otel/flutter_otel.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
+
+/// Records what it was asked to do, for widget/provider tests that take a
+/// [TelemetryServiceInterface] dependency but don't want a real [OTelSdk]
+/// (which would need `WidgetsFlutterBinding` and, if enabled, a network
+/// call) in the loop.
+class FakeTelemetryService implements TelemetryServiceInterface {
+  final List<RecordedTelemetryError> recordedErrors = [];
+  final List<String> loggerNames = [];
+  int flushCount = 0;
+  int shutdownCount = 0;
+
+  @override
+  Logger getLogger({String name = 'truehub', String? version}) {
+    loggerNames.add(name);
+    return _FakeLogger();
+  }
+
+  @override
+  void recordError(
+    Object error,
+    StackTrace stackTrace, {
+    String? context,
+    bool fatal = false,
+  }) {
+    recordedErrors.add(
+      RecordedTelemetryError(
+        error: error,
+        stackTrace: stackTrace,
+        context: context,
+        fatal: fatal,
+      ),
+    );
+  }
+
+  @override
+  Future<void> flush() async => flushCount++;
+
+  @override
+  Future<void> shutdown() async => shutdownCount++;
+}
+
+/// One call to [FakeTelemetryService.recordError], captured for assertions.
+class RecordedTelemetryError {
+  RecordedTelemetryError({
+    required this.error,
+    required this.stackTrace,
+    required this.context,
+    required this.fatal,
+  });
+
+  final Object error;
+  final StackTrace stackTrace;
+  final String? context;
+  final bool fatal;
+}
+
+/// Discards every record - [FakeTelemetryService] only needs to prove
+/// [TelemetryServiceInterface.getLogger] was called with the right scope,
+/// not to inspect what was logged through it.
+class _FakeLogger extends Logger {
+  final List<LogRecord> records = [];
+
+  @override
+  void emit(LogRecord record) => records.add(record);
+}

--- a/test/services/telemetry_bootstrap_test.dart
+++ b/test/services/telemetry_bootstrap_test.dart
@@ -1,0 +1,100 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/services/telemetry_bootstrap.dart';
+import 'package:truehub/services/telemetry_config.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
+
+import '../helpers/fake_telemetry_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const disabledConfig = TelemetryConfig(
+    otlpEndpoint: '',
+    otlpHeaders: {},
+    serviceName: 'truehub-test',
+    deploymentEnvironment: 'test',
+  );
+
+  // FlutterError.onError and PlatformDispatcher.instance.onError are global
+  // mutable state - restore whatever was installed before each test so
+  // bootstrapTelemetry's wiring in one test can't leak into another.
+  late FlutterExceptionHandler? originalFlutterOnError;
+  late ErrorCallback? originalPlatformOnError;
+
+  setUp(() {
+    originalFlutterOnError = FlutterError.onError;
+    originalPlatformOnError = PlatformDispatcher.instance.onError;
+  });
+
+  tearDown(() {
+    FlutterError.onError = originalFlutterOnError;
+    PlatformDispatcher.instance.onError = originalPlatformOnError;
+  });
+
+  group('bootstrapTelemetry', () {
+    test('returns the service produced by the injected initializer', () async {
+      final fake = FakeTelemetryService();
+
+      final result = await bootstrapTelemetry(
+        config: disabledConfig,
+        initializeService: (config) async => fake,
+      );
+
+      expect(result, isA<TelemetryServiceInterface>());
+      expect(result, same(fake));
+    });
+
+    test('a fatal platform error records it and flushes telemetry before '
+        'forwarding to the previously-registered handler', () async {
+      final fake = FakeTelemetryService();
+      var previousHandlerCalled = false;
+      PlatformDispatcher.instance.onError = (error, stack) {
+        previousHandlerCalled = true;
+        return true;
+      };
+
+      await bootstrapTelemetry(
+        config: disabledConfig,
+        initializeService: (config) async => fake,
+      );
+
+      final error = Exception('fatal platform error');
+      final stack = StackTrace.current;
+      final handled = PlatformDispatcher.instance.onError!(error, stack);
+
+      expect(fake.recordedErrors, hasLength(1));
+      final recorded = fake.recordedErrors.single;
+      expect(recorded.error, same(error));
+      expect(recorded.fatal, isTrue);
+      expect(recorded.context, 'PlatformDispatcher.instance.onError');
+
+      // flush() is fire-and-forget (unawaited) so the process can exit
+      // right after onError returns per Flutter's docs - but it must
+      // still have been invoked synchronously before that return.
+      expect(fake.flushCount, 1);
+
+      expect(previousHandlerCalled, isTrue);
+      expect(handled, isTrue);
+    });
+
+    test('a FlutterError.onError call does not trigger a flush', () async {
+      final fake = FakeTelemetryService();
+
+      await bootstrapTelemetry(
+        config: disabledConfig,
+        initializeService: (config) async => fake,
+      );
+
+      FlutterError.onError!(
+        FlutterErrorDetails(exception: Exception('widget build error')),
+      );
+
+      expect(fake.recordedErrors, hasLength(1));
+      expect(fake.recordedErrors.single.fatal, isFalse);
+      expect(fake.flushCount, 0);
+    });
+  });
+}

--- a/test/services/telemetry_config_test.dart
+++ b/test/services/telemetry_config_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/services/telemetry_config.dart';
+
+void main() {
+  group('TelemetryConfig.parseHeaders', () {
+    test('parses a single key=value pair', () {
+      expect(TelemetryConfig.parseHeaders('x-api-key=secret'), {
+        'x-api-key': 'secret',
+      });
+    });
+
+    test('parses multiple comma-separated pairs', () {
+      expect(
+        TelemetryConfig.parseHeaders(
+          'authorization=Bearer abc,x-tenant-id=homelab,x-dataset-id=apps',
+        ),
+        {
+          'authorization': 'Bearer abc',
+          'x-tenant-id': 'homelab',
+          'x-dataset-id': 'apps',
+        },
+      );
+    });
+
+    test(
+      'splits each pair on the first "=" only, keeping later "="s in the value',
+      () {
+        expect(TelemetryConfig.parseHeaders('authorization=Bearer a=b=c'), {
+          'authorization': 'Bearer a=b=c',
+        });
+      },
+    );
+
+    test('trims whitespace around keys, values, and pairs', () {
+      expect(TelemetryConfig.parseHeaders(' key1 = value1 , key2 = value2 '), {
+        'key1': 'value1',
+        'key2': 'value2',
+      });
+    });
+
+    test('returns an empty map for an empty string', () {
+      expect(TelemetryConfig.parseHeaders(''), isEmpty);
+    });
+
+    test('skips blank entries from stray commas', () {
+      expect(TelemetryConfig.parseHeaders('key1=value1,,key2=value2,'), {
+        'key1': 'value1',
+        'key2': 'value2',
+      });
+    });
+
+    test('skips entries with no "=" separator', () {
+      expect(
+        TelemetryConfig.parseHeaders('key1=value1,not-a-pair,key2=value2'),
+        {'key1': 'value1', 'key2': 'value2'},
+      );
+    });
+
+    test('skips entries with an empty key', () {
+      expect(TelemetryConfig.parseHeaders('=value,key=value2'), {
+        'key': 'value2',
+      });
+    });
+
+    test('allows an empty value', () {
+      expect(TelemetryConfig.parseHeaders('key='), {'key': ''});
+    });
+  });
+
+  group('TelemetryConfig.enabled', () {
+    test('is false when otlpEndpoint is empty', () {
+      const config = TelemetryConfig(
+        otlpEndpoint: '',
+        otlpHeaders: {},
+        serviceName: 'truehub',
+        deploymentEnvironment: 'development',
+      );
+
+      expect(config.enabled, isFalse);
+    });
+
+    test('is true when otlpEndpoint is non-empty', () {
+      const config = TelemetryConfig(
+        otlpEndpoint: 'https://collector.example.com',
+        otlpHeaders: {},
+        serviceName: 'truehub',
+        deploymentEnvironment: 'development',
+      );
+
+      expect(config.enabled, isTrue);
+    });
+  });
+
+  group('TelemetryConfig.fromEnvironment', () {
+    test('falls back to documented defaults when no --dart-define is set', () {
+      // The test runner is not invoked with any of these dart-defines, so
+      // this exercises the actual compiled-in default values.
+      final config = TelemetryConfig.fromEnvironment();
+
+      expect(config.otlpEndpoint, isEmpty);
+      expect(config.otlpHeaders, isEmpty);
+      expect(config.serviceName, 'truehub');
+      expect(config.deploymentEnvironment, 'development');
+      expect(config.enabled, isFalse);
+    });
+  });
+}

--- a/test/services/telemetry_service_test.dart
+++ b/test/services/telemetry_service_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_otel/flutter_otel.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truehub/services/telemetry_config.dart';
+import 'package:truehub/services/telemetry_service.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
+
+import '../helpers/fake_telemetry_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Every test below runs with telemetry disabled (no OTLP endpoint), which
+  // makes OTelSdk wire up a no-op exporter internally - real behaviour, no
+  // network I/O. That path is exactly what CI and every un-configured local
+  // build exercise, and it's the only path safe to hit from a unit test.
+  const disabledConfig = TelemetryConfig(
+    otlpEndpoint: '',
+    otlpHeaders: {},
+    serviceName: 'truehub-test',
+    deploymentEnvironment: 'test',
+  );
+
+  tearDown(() async {
+    await OTelSdk.reset();
+  });
+
+  group('TelemetryService (real, disabled config)', () {
+    test(
+      'initialize returns a usable service without a network call',
+      () async {
+        final service = await TelemetryService.initialize(disabledConfig);
+
+        expect(service, isA<TelemetryServiceInterface>());
+      },
+    );
+
+    test(
+      'getLogger returns a Logger that can be used without throwing',
+      () async {
+        final service = await TelemetryService.initialize(disabledConfig);
+
+        final logger = service.getLogger();
+
+        expect(logger, isA<Logger>());
+        expect(() => logger.info('hello from a test'), returnsNormally);
+      },
+    );
+
+    test(
+      'recordError with fatal: false emits an ERROR-severity record via the logger',
+      () async {
+        final service = await TelemetryService.initialize(disabledConfig);
+
+        expect(
+          () => service.recordError(
+            Exception('boom'),
+            StackTrace.current,
+            context: 'unit test',
+          ),
+          returnsNormally,
+        );
+      },
+    );
+
+    test('recordError with fatal: true does not throw', () async {
+      final service = await TelemetryService.initialize(disabledConfig);
+
+      expect(
+        () => service.recordError(
+          Exception('fatal boom'),
+          StackTrace.current,
+          fatal: true,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('flush completes', () async {
+      final service = await TelemetryService.initialize(disabledConfig);
+
+      await expectLater(service.flush(), completes);
+    });
+
+    test('shutdown completes', () async {
+      final service = await TelemetryService.initialize(disabledConfig);
+
+      await expectLater(service.shutdown(), completes);
+    });
+  });
+
+  // Exercises the interface contract itself via a fake, per this repo's
+  // interfaces + DI testing guidelines - anything coded against
+  // TelemetryServiceInterface should be testable without a real OTelSdk.
+  group('TelemetryServiceInterface contract (fake)', () {
+    test('getLogger is recorded and returns a Logger', () {
+      final fake = FakeTelemetryService();
+
+      final logger = fake.getLogger(name: 'my-scope');
+
+      expect(logger, isA<Logger>());
+      expect(fake.loggerNames, ['my-scope']);
+    });
+
+    test(
+      'recordError records the error, stack trace, context, and fatal flag',
+      () {
+        final fake = FakeTelemetryService();
+        final error = Exception('boom');
+        final stackTrace = StackTrace.current;
+
+        fake.recordError(error, stackTrace, context: 'ctx', fatal: true);
+
+        expect(fake.recordedErrors, hasLength(1));
+        final recorded = fake.recordedErrors.single;
+        expect(recorded.error, same(error));
+        expect(recorded.stackTrace, same(stackTrace));
+        expect(recorded.context, 'ctx');
+        expect(recorded.fatal, isTrue);
+      },
+    );
+
+    test('flush and shutdown are counted', () async {
+      final fake = FakeTelemetryService();
+
+      await fake.flush();
+      await fake.flush();
+      await fake.shutdown();
+
+      expect(fake.flushCount, 2);
+      expect(fake.shutdownCount, 1);
+    });
+  });
+}

--- a/test/services/telemetry_service_test.dart
+++ b/test/services/telemetry_service_test.dart
@@ -86,6 +86,32 @@ void main() {
 
       await expectLater(service.shutdown(), completes);
     });
+
+    test('a malformed OTLP endpoint does not throw and falls back to a '
+        'disabled/no-op service instead of crashing app startup', () async {
+      // A build-time misconfiguration (e.g. a bad CI secret) could produce
+      // a string Uri.parse would reject with a FormatException. Since
+      // main() awaits telemetry bootstrap before runApp, that would crash
+      // the whole app before the UI ever renders - initialize must instead
+      // degrade to the same no-op path used when no endpoint is set.
+      const malformedConfig = TelemetryConfig(
+        otlpEndpoint: 'not a valid uri: ::://',
+        otlpHeaders: {},
+        serviceName: 'truehub-test',
+        deploymentEnvironment: 'test',
+      );
+
+      final service = await TelemetryService.initialize(malformedConfig);
+
+      expect(service, isA<TelemetryServiceInterface>());
+      // The service must still be safely usable, exactly like the
+      // disabled-config path above.
+      expect(
+        () => service.recordError(Exception('boom'), StackTrace.current),
+        returnsNormally,
+      );
+      await expectLater(service.flush(), completes);
+    });
   });
 
   // Exercises the interface contract itself via a fake, per this repo's


### PR DESCRIPTION
## Summary

Wires the new [`flutter_otel`](https://github.com/cedricziel/flutter-otel) SDK (companion PR: cedricziel/flutter-otel#1) into trueapp for structured logging to a SignalDB OTLP ingest, configured entirely through build-time `--dart-define` variables — no telemetry code path requires touching call sites elsewhere in the app.

- **Dependency**: `flutter_otel` added as a git dependency (branch ref, pending the companion PR merging/publishing), with `dependency_overrides` for its three sibling packages since they only auto-resolve inside their own Dart workspace. `flutter pub get` confirmed this actually resolves (`pubspec.lock` shows `direct main` / `direct overridden` pinned to the flutter-otel commit).
- **`lib/services/telemetry_config.dart`**: reads `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, `OTEL_DEPLOYMENT_ENVIRONMENT` from compile-time env; telemetry is enabled only when an endpoint is configured.
- **`lib/services/telemetry_service_interface.dart` / `telemetry_service.dart`**: interface + implementation wrapping `OTelSdk`, per this repo's DI/testability conventions. Always initializes the SDK (using its no-op exporter mode when disabled) so callers never need null checks.
- **`main.dart`**: bootstraps telemetry before `runApp` and chains `FlutterError.onError` / `PlatformDispatcher.instance.onError` through `TelemetryService.recordError(...)`, so uncaught errors become OTel log records automatically. Exposed via `Provider<TelemetryServiceInterface>`.
- **CI / release builds** (`.github/workflows/ci.yml`, `fastlane/Fastfile`): both now pass the OTel dart-defines, sourced from repo secrets `OTLP_INGEST_URL` / `OTLP_INGEST_KEY`, composed per SignalDB's documented auth contract:
  `authorization=Bearer <key>,x-tenant-id=homelab,x-dataset-id=apps`.
  A missing secret just leaves telemetry disabled — it never fails the build.
- trueapp's actual network layer is JSON-RPC over WebSocket, not Dio (Dio is an unused pubspec entry), so the SDK's Dio instrumentation package wasn't wired in here.

## Testing

- `flutter analyze`: clean
- `flutter test --coverage`: 1033 passed
- `dart run tool/check_coverage.dart`: 85.4% (floor 85%) — passes
- `ruby fastlane/test/pubspec_version_test.rb`, `ruby -c fastlane/Fastfile`, YAML parse of `ci.yml`: all clean

## Follow-up

- Depends on cedricziel/flutter-otel#1 merging (or being published) — once it is, drop the `dependency_overrides` block in `pubspec.yaml` and pin `flutter_otel` to a real version/tag instead of a branch ref.
- SignalDB's OTLP header names (`Authorization`, `X-Tenant-ID`, `X-Dataset-ID`) were verified against that project's own docs, not guessed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014EK3pYRTW2RBbaJGDtQq99)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OpenTelemetry telemetry for Flutter app diagnostics.
  * Captures structured fatal and nonfatal errors, including Flutter framework and platform failures.
  * Supports configurable telemetry endpoints, authentication, service names, and deployment environments.
  * Telemetry remains disabled when no endpoint is configured.

* **Build & Reliability**
  * iOS and macOS builds now accept optional telemetry settings without failing when credentials are unavailable.
  * Added lifecycle handling to flush and safely shut down telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->