### PR TITLE
feat: wire OTel tracing into TrueNasApiClient's connection flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ void main() async {
 
   // Initialize services
   ApiClientManager.setConnectionStatusProvider(connectionStatusProvider);
+  ApiClientManager.setTelemetryService(telemetryService);
 
   runApp(
     MultiProvider(

--- a/lib/services/api_client_manager.dart
+++ b/lib/services/api_client_manager.dart
@@ -5,6 +5,7 @@ import 'package:truehub/services/api_client_interface.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:truehub/services/api_client_manager_interface.dart';
 import 'package:truehub/services/api_client_manager_impl.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
 
 /// Legacy static facade for ApiClientManager
 /// This maintains backward compatibility while allowing for dependency injection
@@ -26,6 +27,10 @@ class ApiClientManager {
   // Legacy static methods that delegate to instance
   static void setConnectionStatusProvider(ConnectionStatusProvider? provider) {
     instance.setConnectionStatusProvider(provider);
+  }
+
+  static void setTelemetryService(TelemetryServiceInterface? telemetry) {
+    instance.setTelemetryService(telemetry);
   }
 
   static Future<ApiClientInterface?> getClient(NasServer server) async {

--- a/lib/services/api_client_manager_impl.dart
+++ b/lib/services/api_client_manager_impl.dart
@@ -5,6 +5,7 @@ import 'package:truehub/services/truenas_api_client.dart';
 import 'package:truehub/services/api_client_interface.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:truehub/services/api_client_manager_interface.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
 
 /// Default implementation of ApiClientManagerInterface
 class ApiClientManagerImpl implements ApiClientManagerInterface {
@@ -12,10 +13,16 @@ class ApiClientManagerImpl implements ApiClientManagerInterface {
   final Map<String, int> _refCounts = {};
   final Map<String, Completer<TrueNasApiClient>?> _connectionCompleters = {};
   ConnectionStatusProvider? _connectionStatusProvider;
+  TelemetryServiceInterface? _telemetry;
 
   @override
   void setConnectionStatusProvider(ConnectionStatusProvider? provider) {
     _connectionStatusProvider = provider;
+  }
+
+  @override
+  void setTelemetryService(TelemetryServiceInterface? telemetry) {
+    _telemetry = telemetry;
   }
 
   @override
@@ -59,7 +66,11 @@ class ApiClientManagerImpl implements ApiClientManagerInterface {
         );
       }
 
-      final client = TrueNasApiClient(server, _connectionStatusProvider);
+      final client = TrueNasApiClient(
+        server,
+        _connectionStatusProvider,
+        _telemetry,
+      );
       _clients[serverId] = client;
       _refCounts[serverId] = 1;
 
@@ -257,5 +268,6 @@ class ApiClientManagerImpl implements ApiClientManagerInterface {
     _refCounts.clear();
     _connectionCompleters.clear();
     _connectionStatusProvider = null;
+    _telemetry = null;
   }
 }

--- a/lib/services/api_client_manager_interface.dart
+++ b/lib/services/api_client_manager_interface.dart
@@ -2,11 +2,16 @@ import 'dart:async';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/services/api_client_interface.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
 
 /// Interface for managing TrueNAS API client instances
 abstract class ApiClientManagerInterface {
   /// Set the connection status provider
   void setConnectionStatusProvider(ConnectionStatusProvider? provider);
+
+  /// Set the telemetry service used to instrument clients created from now
+  /// on (existing clients are unaffected).
+  void setTelemetryService(TelemetryServiceInterface? telemetry);
 
   /// Get or create a client for the given server
   Future<ApiClientInterface?> getClient(NasServer server);

--- a/lib/services/telemetry_service.dart
+++ b/lib/services/telemetry_service.dart
@@ -46,6 +46,10 @@ class TelemetryService implements TelemetryServiceInterface {
       _sdk.getLogger(name: name, version: version);
 
   @override
+  Tracer getTracer({String name = 'truehub', String? version}) =>
+      _sdk.getTracer(name: name, version: version);
+
+  @override
   void recordError(
     Object error,
     StackTrace stackTrace, {

--- a/lib/services/telemetry_service_interface.dart
+++ b/lib/services/telemetry_service_interface.dart
@@ -10,6 +10,11 @@ abstract class TelemetryServiceInterface {
   /// name/version pair.
   Logger getLogger({String name = 'truehub', String? version});
 
+  /// Returns a [Tracer] for the given instrumentation scope. Implementations
+  /// typically cache and return the same instance for a given
+  /// name/version pair.
+  Tracer getTracer({String name = 'truehub', String? version});
+
   /// Records an error and its stack trace as a log record - the intended
   /// target for `FlutterError.onError` / `PlatformDispatcher.instance.onError`
   /// hooks, and for any `catch` block that wants a caught error to surface

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_otel/flutter_otel.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:truehub/models/nas_server.dart';
@@ -14,11 +15,13 @@ import 'package:truehub/models/system_stats.dart';
 import 'package:truehub/services/network_service.dart';
 import 'package:truehub/services/api_client_interface.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
 
 class TrueNasApiClient implements ApiClientInterface {
   final NasServer _server;
   final NetworkService _networkService = NetworkService();
   final ConnectionStatusProvider? _connectionStatusProvider;
+  final TelemetryServiceInterface? _telemetry;
   Peer? _client;
   WebSocketChannel? _wsChannel;
   bool _isAuthenticated = false;
@@ -58,7 +61,11 @@ class TrueNasApiClient implements ApiClientInterface {
   Duration _keepaliveInterval = const Duration(seconds: 30);
   bool _awaitingPong = false;
 
-  TrueNasApiClient(this._server, [this._connectionStatusProvider]);
+  TrueNasApiClient(
+    this._server, [
+    this._connectionStatusProvider,
+    this._telemetry,
+  ]);
 
   /// Whether the JSON-RPC socket is currently usable.
   bool get _hasLiveConnection => _client != null && !_client!.isClosed;
@@ -68,6 +75,24 @@ class TrueNasApiClient implements ApiClientInterface {
       return;
     }
 
+    final telemetry = _telemetry;
+    if (telemetry == null) {
+      return _ensureConnectedTraced(null);
+    }
+
+    return telemetry.getTracer().startActiveSpan(
+      'truenas.connect',
+      (span) => _ensureConnectedTraced(span),
+      kind: SpanKind.client,
+      attributes: {'server.id': _server.id},
+    );
+  }
+
+  /// The body of [_ensureConnected]. [span] is the active span for this
+  /// connection attempt when telemetry is wired up, or `null` when it isn't
+  /// - every telemetry touch below is guarded on it so this method's
+  /// behaviour is identical either way beyond that instrumentation.
+  Future<void> _ensureConnectedTraced(Span? span) async {
     _connectionStatusProvider?.updateConnectionState(
       _server.id,
       TrueNASConnectionState.connecting,
@@ -85,6 +110,10 @@ class TrueNasApiClient implements ApiClientInterface {
       final wsUrl = '${baseUrl.replaceFirst('http', 'ws')}/api/current';
       _currentConnectionUrl = baseUrl;
       _isLocalConnection = isOnTrustedNetwork;
+
+      // Not the URL itself - it can carry user-info/credentials-shaped query
+      // parameters - just whether this connection stayed on the trusted LAN.
+      span?.setAttribute('server.network.trusted', isOnTrustedNetwork);
 
       if (kDebugMode) {
         print('TrueNAS API: Connecting to WebSocket: $wsUrl');
@@ -132,7 +161,8 @@ class TrueNasApiClient implements ApiClientInterface {
       if (kDebugMode) {
         print('TrueNAS API: WebSocket connection established and listening');
       }
-    } catch (e) {
+      span?.setStatus(StatusCode.ok);
+    } catch (e, stackTrace) {
       if (kDebugMode) {
         print('TrueNAS API: Connection failed: $e');
       }
@@ -149,6 +179,16 @@ class TrueNasApiClient implements ApiClientInterface {
         _server.id,
         TrueNASConnectionState.error,
         error: e.toString(),
+      );
+      // The span's own exception/error-status recording is handled by
+      // Tracer.startActiveSpan's contract (it records whatever this method
+      // throws and marks the span an error) - this only needs to get the
+      // failure into the logs signal too.
+      _telemetry?.getLogger().error(
+        'TrueNAS API: Connection failed',
+        error: e,
+        stackTrace: stackTrace,
+        attributes: {'server.id': _server.id},
       );
       throw _handleConnectionError(e);
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -344,7 +344,7 @@ packages:
     description:
       path: "packages/flutter_otel"
       ref: main
-      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
+      resolved-ref: "3ff0c411a2df6f844b943015efb9fb78d4e5f836"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"
@@ -353,7 +353,7 @@ packages:
     description:
       path: "packages/flutter_otel_api"
       ref: main
-      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
+      resolved-ref: "3ff0c411a2df6f844b943015efb9fb78d4e5f836"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"
@@ -362,7 +362,7 @@ packages:
     description:
       path: "packages/flutter_otel_exporter_otlp_http"
       ref: main
-      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
+      resolved-ref: "3ff0c411a2df6f844b943015efb9fb78d4e5f836"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"
@@ -371,7 +371,7 @@ packages:
     description:
       path: "packages/flutter_otel_sdk"
       ref: main
-      resolved-ref: "87e3aa465e5102f96281ea0810cfd47f12223bf6"
+      resolved-ref: "3ff0c411a2df6f844b943015efb9fb78d4e5f836"
       url: "https://github.com/cedricziel/flutter-otel.git"
     source: git
     version: "0.1.0"

--- a/test/helpers/fake_telemetry_service.dart
+++ b/test/helpers/fake_telemetry_service.dart
@@ -8,6 +8,13 @@ import 'package:truehub/services/telemetry_service_interface.dart';
 class FakeTelemetryService implements TelemetryServiceInterface {
   final List<RecordedTelemetryError> recordedErrors = [];
   final List<String> loggerNames = [];
+  final List<String> tracerNames = [];
+
+  /// Every [FakeSpan] started by any [Tracer] this service has vended, in
+  /// start order - the seam tests use to assert on attributes/status/
+  /// exceptions without needing a real SDK span pipeline.
+  final List<FakeSpan> spans = [];
+
   int flushCount = 0;
   int shutdownCount = 0;
 
@@ -15,6 +22,12 @@ class FakeTelemetryService implements TelemetryServiceInterface {
   Logger getLogger({String name = 'truehub', String? version}) {
     loggerNames.add(name);
     return _FakeLogger();
+  }
+
+  @override
+  Tracer getTracer({String name = 'truehub', String? version}) {
+    tracerNames.add(name);
+    return _FakeTracer(name, spans);
   }
 
   @override
@@ -64,4 +77,176 @@ class _FakeLogger extends Logger {
 
   @override
   void emit(LogRecord record) => records.add(record);
+}
+
+/// Minimal [Tracer] fake that records started spans into a shared list and
+/// mirrors `SdkTracer.startActiveSpan`'s real contract (record the
+/// exception, set an error status, end the span, rethrow) so tests can
+/// assert against it the same way they would against the real SDK.
+class _FakeTracer implements Tracer {
+  _FakeTracer(this.name, this._spans);
+
+  @override
+  final String name;
+
+  final List<FakeSpan> _spans;
+
+  @override
+  Span startSpan(
+    String name, {
+    SpanKind kind = SpanKind.internal,
+    Map<String, Object?>? attributes,
+    SpanContext? parentContext,
+  }) {
+    final span = FakeSpan(name, kind: kind, attributes: attributes);
+    _spans.add(span);
+    return span;
+  }
+
+  @override
+  Future<T> startActiveSpan<T>(
+    String name,
+    Future<T> Function(Span span) body, {
+    SpanKind kind = SpanKind.internal,
+    Map<String, Object?>? attributes,
+  }) async {
+    final span = startSpan(name, kind: kind, attributes: attributes);
+    try {
+      return await Span.runWithSpan(span, () => body(span));
+    } catch (e, stackTrace) {
+      span.recordException(e, stackTrace: stackTrace);
+      span.setStatus(StatusCode.error, description: e.toString());
+      rethrow;
+    } finally {
+      span.end();
+    }
+  }
+}
+
+/// A [Span] fake that records every mutation made to it - attributes,
+/// events, status, and recorded exceptions - for tests to assert against.
+/// Following [_FakeLogger]'s "record what it was asked to do" philosophy.
+class FakeSpan implements Span {
+  FakeSpan(this.name, {required this.kind, Map<String, Object?>? attributes})
+    : attributes = Map.of(attributes ?? const {});
+
+  @override
+  final String name;
+
+  /// The [SpanKind] this span was started with.
+  final SpanKind kind;
+
+  /// Merged attribute set, updated in place by [setAttribute]/
+  /// [setAttributes] - reflects the span's current attributes, not a log of
+  /// individual calls.
+  final Map<String, Object?> attributes;
+
+  /// Every [addEvent] call, in order.
+  final List<RecordedSpanEvent> events = [];
+
+  /// Every [recordException] call, in order.
+  final List<RecordedSpanException> exceptions = [];
+
+  /// The status set by the most recent [setStatus] call - [StatusCode.unset]
+  /// until one is made.
+  StatusCode status = StatusCode.unset;
+
+  /// The `description` from the most recent [setStatus] call, if any.
+  String? statusDescription;
+
+  bool _ended = false;
+
+  /// Whether [end] has been called on this span.
+  bool get isEnded => _ended;
+
+  @override
+  final SpanContext spanContext = const SpanContext(
+    traceId: 'ffffffffffffffffffffffffffffffff',
+    spanId: 'ffffffffffffffff',
+  );
+
+  @override
+  bool get isRecording => !_ended;
+
+  @override
+  void setAttribute(String key, Object? value) {
+    if (_ended) return;
+    attributes[key] = value;
+  }
+
+  @override
+  void setAttributes(Map<String, Object?> attributes) {
+    if (_ended) return;
+    this.attributes.addAll(attributes);
+  }
+
+  @override
+  void addEvent(
+    String name, {
+    Map<String, Object?>? attributes,
+    DateTime? timestamp,
+  }) {
+    if (_ended) return;
+    events.add(
+      RecordedSpanEvent(
+        name: name,
+        attributes: attributes ?? const {},
+        timestamp: timestamp,
+      ),
+    );
+  }
+
+  @override
+  void setStatus(StatusCode code, {String? description}) {
+    if (_ended) return;
+    status = code;
+    statusDescription = description;
+  }
+
+  @override
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Map<String, Object?>? attributes,
+  }) {
+    if (_ended) return;
+    exceptions.add(
+      RecordedSpanException(
+        exception: exception,
+        stackTrace: stackTrace,
+        attributes: attributes ?? const {},
+      ),
+    );
+  }
+
+  @override
+  void end([DateTime? endTime]) {
+    _ended = true;
+  }
+}
+
+/// One [FakeSpan.addEvent] call, captured for assertions.
+class RecordedSpanEvent {
+  RecordedSpanEvent({
+    required this.name,
+    required this.attributes,
+    required this.timestamp,
+  });
+
+  final String name;
+  final Map<String, Object?> attributes;
+  final DateTime? timestamp;
+}
+
+/// One [FakeSpan.recordException] call, captured for assertions.
+class RecordedSpanException {
+  RecordedSpanException({
+    required this.exception,
+    required this.stackTrace,
+    required this.attributes,
+  });
+
+  final Object exception;
+  final StackTrace? stackTrace;
+  final Map<String, Object?> attributes;
 }

--- a/test/helpers/mock_api_client_manager.dart
+++ b/test/helpers/mock_api_client_manager.dart
@@ -11,7 +11,10 @@ class MockApiClientManager implements ApiClientManagerInterface {
   final Map<String, ApiClientInterface?> _mockClients = {};
   final Map<String, int> _mockRefCounts = {};
   ConnectionStatusProvider? _connectionStatusProvider; // ignore: unused_field
-  TelemetryServiceInterface? _telemetry; // ignore: unused_field
+
+  /// The last value passed to [setTelemetryService], exposed for tests that
+  /// verify `ApiClientManager`'s static facade actually delegates here.
+  TelemetryServiceInterface? telemetry;
 
   // Test control flags
   bool shouldFailConnection = false;
@@ -30,7 +33,7 @@ class MockApiClientManager implements ApiClientManagerInterface {
   @override
   void setTelemetryService(TelemetryServiceInterface? telemetry) {
     methodCalls.add('setTelemetryService');
-    _telemetry = telemetry;
+    this.telemetry = telemetry;
   }
 
   @override
@@ -143,7 +146,7 @@ class MockApiClientManager implements ApiClientManagerInterface {
     _mockClients.clear();
     _mockRefCounts.clear();
     _connectionStatusProvider = null;
-    _telemetry = null;
+    telemetry = null;
     methodCalls.clear();
   }
 

--- a/test/helpers/mock_api_client_manager.dart
+++ b/test/helpers/mock_api_client_manager.dart
@@ -4,12 +4,14 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/services/api_client_interface.dart';
 import 'package:truehub/providers/connection_status_provider.dart';
 import 'package:truehub/services/api_client_manager_interface.dart';
+import 'package:truehub/services/telemetry_service_interface.dart';
 
 /// Mock implementation of ApiClientManagerInterface for testing
 class MockApiClientManager implements ApiClientManagerInterface {
   final Map<String, ApiClientInterface?> _mockClients = {};
   final Map<String, int> _mockRefCounts = {};
   ConnectionStatusProvider? _connectionStatusProvider; // ignore: unused_field
+  TelemetryServiceInterface? _telemetry; // ignore: unused_field
 
   // Test control flags
   bool shouldFailConnection = false;
@@ -23,6 +25,12 @@ class MockApiClientManager implements ApiClientManagerInterface {
   void setConnectionStatusProvider(ConnectionStatusProvider? provider) {
     methodCalls.add('setConnectionStatusProvider');
     _connectionStatusProvider = provider;
+  }
+
+  @override
+  void setTelemetryService(TelemetryServiceInterface? telemetry) {
+    methodCalls.add('setTelemetryService');
+    _telemetry = telemetry;
   }
 
   @override
@@ -135,6 +143,7 @@ class MockApiClientManager implements ApiClientManagerInterface {
     _mockClients.clear();
     _mockRefCounts.clear();
     _connectionStatusProvider = null;
+    _telemetry = null;
     methodCalls.clear();
   }
 

--- a/test/services/api_client_manager_test.dart
+++ b/test/services/api_client_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:truehub/services/api_client_manager.dart';
 import 'package:truehub/services/truenas_api_client.dart';
 
 import '../helpers/fake_telemetry_service.dart';
+import '../helpers/mock_api_client_manager.dart';
 
 void main() {
   group('ApiClientManager', () {
@@ -261,6 +262,18 @@ void main() {
         // cover the telemetry behaviour itself.
         final client = await ApiClientManager.getClient(testServer1);
         expect(client, isA<TrueNasApiClient>());
+      });
+
+      test('static facade delegates to the underlying instance', () {
+        final mock = MockApiClientManager();
+        ApiClientManager.setInstance(mock);
+        addTearDown(() => ApiClientManager.setInstance(null));
+
+        final telemetry = FakeTelemetryService();
+        ApiClientManager.setTelemetryService(telemetry);
+
+        expect(mock.methodCalls, contains('setTelemetryService'));
+        expect(mock.telemetry, same(telemetry));
       });
     });
 

--- a/test/services/api_client_manager_test.dart
+++ b/test/services/api_client_manager_test.dart
@@ -4,6 +4,8 @@ import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/services/api_client_manager.dart';
 import 'package:truehub/services/truenas_api_client.dart';
 
+import '../helpers/fake_telemetry_service.dart';
+
 void main() {
   group('ApiClientManager', () {
     late NasServer testServer1;
@@ -237,6 +239,28 @@ void main() {
           () => ApiClientManager.setConnectionStatusProvider(null),
           returnsNormally,
         );
+      });
+    });
+
+    group('setTelemetryService', () {
+      test('accepts a null service without throwing', () {
+        expect(
+          () => ApiClientManager.setTelemetryService(null),
+          returnsNormally,
+        );
+      });
+
+      test('is passed through to clients created afterwards', () async {
+        final telemetry = FakeTelemetryService();
+        ApiClientManager.setTelemetryService(telemetry);
+        addTearDown(() => ApiClientManager.setTelemetryService(null));
+
+        // Nothing observable on ApiClientManagerInterface exposes the
+        // telemetry service directly, so this only proves getClient()
+        // doesn't blow up with one wired in - TrueNasApiClient's own tests
+        // cover the telemetry behaviour itself.
+        final client = await ApiClientManager.getClient(testServer1);
+        expect(client, isA<TrueNasApiClient>());
       });
     });
 

--- a/test/services/telemetry_service_test.dart
+++ b/test/services/telemetry_service_test.dart
@@ -47,6 +47,24 @@ void main() {
     );
 
     test(
+      'getTracer returns a Tracer that can be used without throwing',
+      () async {
+        final service = await TelemetryService.initialize(disabledConfig);
+
+        final tracer = service.getTracer();
+
+        expect(tracer, isA<Tracer>());
+        await expectLater(
+          tracer.startActiveSpan(
+            'test-span',
+            (span) async => span.setStatus(StatusCode.ok),
+          ),
+          completes,
+        );
+      },
+    );
+
+    test(
       'recordError with fatal: false emits an ERROR-severity record via the logger',
       () async {
         final service = await TelemetryService.initialize(disabledConfig);
@@ -125,6 +143,62 @@ void main() {
 
       expect(logger, isA<Logger>());
       expect(fake.loggerNames, ['my-scope']);
+    });
+
+    test('getTracer is recorded and returns a Tracer', () {
+      final fake = FakeTelemetryService();
+
+      final tracer = fake.getTracer(name: 'my-scope');
+
+      expect(tracer, isA<Tracer>());
+      expect(fake.tracerNames, ['my-scope']);
+    });
+
+    test(
+      'a started span records attributes/status and is captured in spans',
+      () async {
+        final fake = FakeTelemetryService();
+        final tracer = fake.getTracer();
+
+        await tracer.startActiveSpan(
+          'my-span',
+          (span) async {
+            span.setAttribute('server.id', 'abc');
+            span.setStatus(StatusCode.ok);
+          },
+          kind: SpanKind.client,
+          attributes: {'initial': true},
+        );
+
+        expect(fake.spans, hasLength(1));
+        final span = fake.spans.single;
+        expect(span.name, 'my-span');
+        expect(span.kind, SpanKind.client);
+        expect(span.attributes, {'initial': true, 'server.id': 'abc'});
+        expect(span.status, StatusCode.ok);
+        expect(span.isEnded, isTrue);
+      },
+    );
+
+    test('a span whose body throws records the exception and an error status, '
+        'then rethrows', () async {
+      final fake = FakeTelemetryService();
+      final tracer = fake.getTracer();
+      final error = Exception('boom');
+
+      await expectLater(
+        tracer.startActiveSpan('failing-span', (span) async {
+          throw error;
+        }),
+        throwsA(same(error)),
+      );
+
+      expect(fake.spans, hasLength(1));
+      final span = fake.spans.single;
+      expect(span.status, StatusCode.error);
+      expect(span.exceptions, hasLength(1));
+      expect(span.exceptions.single.exception, same(error));
+      expect(span.isEnded, isTrue);
     });
 
     test(

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter_otel/flutter_otel.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/services/truenas_api_client.dart';
 
+import '../helpers/fake_telemetry_service.dart';
 import '../helpers/fake_truenas_server.dart';
 
 void main() {
@@ -719,5 +721,87 @@ void main() {
         expect(client.isKeepaliveActive, isTrue);
       },
     );
+  });
+
+  group('TrueNasApiClient connection telemetry', () {
+    late FakeTrueNasServer server;
+    late NasServer testServer;
+
+    NasServer serverFor(FakeTrueNasServer s) => NasServer(
+      id: 'telemetry-fake-server',
+      name: 'Telemetry Fake Server',
+      host: '127.0.0.1',
+      port: s.port,
+      useHttps: false,
+      username: 'root',
+      password: 'password',
+      localUrl: null,
+      trustedWifiSsids: const [],
+      isDefault: false,
+    );
+
+    setUp(() async {
+      server = await FakeTrueNasServer.start();
+      testServer = serverFor(server);
+    });
+
+    tearDown(() async {
+      await server.stop();
+    });
+
+    test('a successful connect produces a truenas.connect span with '
+        'StatusCode.ok and the expected attributes', () async {
+      final telemetry = FakeTelemetryService();
+      final client = TrueNasApiClient(testServer, null, telemetry);
+      addTearDown(client.close);
+
+      // getCurrentUser() drives _ensureAuthenticated -> _ensureConnected.
+      await client.getCurrentUser();
+
+      expect(telemetry.spans, hasLength(1));
+      final span = telemetry.spans.single;
+      expect(span.name, 'truenas.connect');
+      expect(span.kind, SpanKind.client);
+      expect(span.attributes['server.id'], testServer.id);
+      expect(span.attributes['server.network.trusted'], isFalse);
+      expect(span.status, StatusCode.ok);
+      expect(span.isEnded, isTrue);
+      expect(telemetry.tracerNames, isNotEmpty);
+    });
+
+    test(
+      'a failed connect produces an error span and still calls the logger',
+      () async {
+        // Nothing listens on this server's port once it has been stopped,
+        // so the connect attempt fails deterministically - same technique
+        // the plain (non-telemetry) failure test above uses.
+        await server.stop();
+
+        final telemetry = FakeTelemetryService();
+        final deadClient = TrueNasApiClient(testServer, null, telemetry);
+        addTearDown(deadClient.close);
+
+        final result = await deadClient.validateLogin('root', 'password');
+
+        expect(result, isFalse);
+        expect(telemetry.spans, hasLength(1));
+        final span = telemetry.spans.single;
+        expect(span.name, 'truenas.connect');
+        expect(span.status, StatusCode.error);
+        expect(span.exceptions, isNotEmpty);
+        expect(span.isEnded, isTrue);
+        // The catch block in _ensureConnectedTraced logs the failure too.
+        expect(telemetry.loggerNames, isNotEmpty);
+      },
+    );
+
+    test('passing telemetry: null behaves identically to the untraced client '
+        '(no crash, same success/failure outcomes)', () async {
+      final client = TrueNasApiClient(testServer);
+      addTearDown(client.close);
+
+      await client.getCurrentUser();
+      expect(client.isKeepaliveActive, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Pulls in `flutter_otel`'s new traces signal (cedricziel/flutter-otel#2, merged) and wires the first real span into the app: `TrueNasApiClient`'s WebSocket/JSON-RPC connection flow.

- **Lockfile bump**: `flutter_otel`/`flutter_otel_api`/`flutter_otel_sdk`/`flutter_otel_exporter_otlp_http` in `pubspec.lock` now resolve to `3ff0c41` (flutter-otel's current `main`, confirmed via `git ls-remote`), up from the stale `87e3aa4` pinned when only the logs signal existed. `pubspec.yaml`'s `ref: main` / `dependency_overrides` setup is unchanged.
- **`TelemetryServiceInterface`/`TelemetryService`**: added `getTracer({name, version})`, mirroring the existing `getLogger` passthrough. `FakeTelemetryService` gained a fake tracer/span implementation for tests.
- **`TrueNasApiClient` connection tracing**: `_ensureConnected()` now wraps the connect attempt in a `truenas.connect` CLIENT span (attributes: `server.id`, `server.network.trusted` — deliberately no URLs or credential-shaped data on the span, consistent with the caution already documented in the Dio instrumentation package) when telemetry is wired in. Success sets `StatusCode.ok`; failure logs the error via the app's `Logger` (span exception/error-status recording is automatic — `Tracer.startActiveSpan`'s own contract handles that on a thrown exception, verified against the SDK source rather than assumed).
- **Wiring pattern**: threaded through `TrueNasApiClient` → `ApiClientManagerImpl`/`ApiClientManagerInterface`/`ApiClientManager` exactly the way `ConnectionStatusProvider` already is (an optional dependency, static setter, `main.dart` wiring it up once at startup) — no new pattern introduced. Fully optional throughout: passing `telemetry: null` (the default in every other existing call site) leaves `_ensureConnected()`'s behavior byte-for-byte unchanged.

This also gives trueapp its first piece of genuinely *routine* telemetry (not just crash-path logging via the global error handlers) — every server connection attempt now produces a span and, on failure, a structured log line.

## Testing

- `flutter analyze`: clean
- `flutter test --coverage`: 1051 passed
- `dart run tool/check_coverage.dart`: 85.5% (floor 85%) — passes
- New coverage: `TelemetryService.getTracer` delegation, `FakeTelemetryService`'s tracer/span behavior (attributes, ok/error status, exception recording), `ApiClientManager.setTelemetryService` plumbing (mirroring the existing `setConnectionStatusProvider` test group), and a `TrueNasApiClient connection telemetry` group covering success, failure, and the `telemetry: null` no-op case.

---
_Generated by [Claude Code](https://claude.ai/code/session_014EK3pYRTW2RBbaJGDtQq99)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry tracing for API client connection attempts.
  * Successful connections now record network status and completion details.
  * Failed connections capture errors and diagnostic information for improved observability.
  * Added configurable tracer creation with optional name and version settings.

* **Tests**
  * Added coverage for telemetry configuration, successful connections, failures, span data, and error handling.
  * Confirmed compatibility when telemetry is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->