### PR TITLE
fix: close the AppResourceUsage.last_updated parsing gap, and extend tracing to cover it

### DIFF
--- a/lib/models/app.dart
+++ b/lib/models/app.dart
@@ -1,5 +1,40 @@
 import 'package:equatable/equatable.dart';
 
+/// TrueNAS has returned datetime fields (`App.last_update`,
+/// `AppResourceUsage.last_updated`, ...) in more than one shape across SCALE
+/// versions: MongoDB-style extended JSON (`{"$date": <epoch ms>}`), a raw
+/// epoch-millisecond number, or an ISO 8601 string. Parsing defensively
+/// (rather than indexing straight into `['\$date']` or assuming a `String`)
+/// keeps a server on an unexpected shape from throwing a raw type error out
+/// of a model's `fromJson` - which previously surfaced to users as a generic
+/// "Connection error" with no indication the app list itself parsed fine
+/// except for this one field.
+DateTime? _parseTrueNasDate(dynamic value) {
+  if (value == null) return null;
+  try {
+    if (value is Map) {
+      final epochMs = value['\$date'];
+      if (epochMs is num) {
+        return DateTime.fromMillisecondsSinceEpoch(epochMs.toInt());
+      }
+      return null;
+    }
+    if (value is num) {
+      return DateTime.fromMillisecondsSinceEpoch(value.toInt());
+    }
+    if (value is String) {
+      return DateTime.tryParse(value) ??
+          (int.tryParse(value) != null
+              ? DateTime.fromMillisecondsSinceEpoch(int.parse(value))
+              : null);
+    }
+  } catch (_) {
+    // Fall through to null below - an unparseable date shouldn't break
+    // parsing the rest of the app's data.
+  }
+  return null;
+}
+
 class AppMaintainer extends Equatable {
   final String name;
   final String email;
@@ -51,9 +86,7 @@ class AppResourceUsage extends Equatable {
       memoryLimit: (json['memory_limit'] as num?)?.toInt() ?? 0,
       networkRxBytes: (json['network_rx_bytes'] as num?)?.toDouble() ?? 0.0,
       networkTxBytes: (json['network_tx_bytes'] as num?)?.toDouble() ?? 0.0,
-      lastUpdated: json['last_updated'] != null
-          ? DateTime.tryParse(json['last_updated'] as String)
-          : null,
+      lastUpdated: _parseTrueNasDate(json['last_updated']),
     );
   }
 
@@ -259,40 +292,6 @@ class App extends Equatable {
     return null;
   }
 
-  /// TrueNAS has returned `last_update` in more than one shape across SCALE
-  /// versions: MongoDB-style extended JSON (`{"$date": <epoch ms>}`), a raw
-  /// epoch-millisecond number, or an ISO 8601 string. Parsing this
-  /// defensively (rather than indexing straight into `['\$date']`) keeps a
-  /// server on an unexpected shape from throwing a raw type error out of
-  /// [App.fromJson] - which previously surfaced to users as a generic
-  /// "Connection error" with no indication the app list itself parsed fine
-  /// except for this one field.
-  static DateTime? _parseLastUpdate(dynamic value) {
-    if (value == null) return null;
-    try {
-      if (value is Map) {
-        final epochMs = value['\$date'];
-        if (epochMs is num) {
-          return DateTime.fromMillisecondsSinceEpoch(epochMs.toInt());
-        }
-        return null;
-      }
-      if (value is num) {
-        return DateTime.fromMillisecondsSinceEpoch(value.toInt());
-      }
-      if (value is String) {
-        return DateTime.tryParse(value) ??
-            (int.tryParse(value) != null
-                ? DateTime.fromMillisecondsSinceEpoch(int.parse(value))
-                : null);
-      }
-    } catch (_) {
-      // Fall through to null below - an unparseable date shouldn't break
-      // parsing the rest of the app's data.
-    }
-    return null;
-  }
-
   factory App.fromJson(Map<String, dynamic> json) {
     return App(
       name: json['name'] as String? ?? '',
@@ -330,7 +329,7 @@ class App extends Equatable {
               ?.map((e) => AppMaintainer.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],
-      lastUpdate: _parseLastUpdate(json['last_update']),
+      lastUpdate: _parseTrueNasDate(json['last_update']),
       recommended: json['recommended'] as bool? ?? false,
       catalog: json['catalog'] as String? ?? '',
       train: json['train'] as String? ?? '',

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -194,6 +194,48 @@ class TrueNasApiClient implements ApiClientInterface {
     }
   }
 
+  /// Runs [body] in a CLIENT span named [spanName] (a no-op wrapper when
+  /// telemetry isn't wired up) and logs a failure via the telemetry Logger
+  /// before rethrowing.
+  ///
+  /// `truenas.connect` (above) only covers establishing the socket and
+  /// authenticating - it was added to diagnose "failed to load apps"
+  /// reports, but a request that connects and authenticates fine and then
+  /// fails while parsing the *response* (e.g. an app whose `last_update`
+  /// or `resources` shape TrueNAS returns differently than expected) threw
+  /// past that span entirely, with nothing recording what broke. Wrapping
+  /// the request+parse methods themselves closes that gap.
+  Future<T> _traced<T>(String spanName, Future<T> Function() body) async {
+    final telemetry = _telemetry;
+    if (telemetry == null) {
+      return body();
+    }
+
+    return telemetry.getTracer().startActiveSpan(
+      spanName,
+      (span) async {
+        try {
+          final result = await body();
+          span.setStatus(StatusCode.ok);
+          return result;
+        } catch (e, stackTrace) {
+          // The span's own exception/error-status recording is handled by
+          // Tracer.startActiveSpan's contract - this only needs to get the
+          // failure into the logs signal too.
+          telemetry.getLogger().error(
+            'TrueNAS API: $spanName failed',
+            error: e,
+            stackTrace: stackTrace,
+            attributes: {'server.id': _server.id},
+          );
+          rethrow;
+        }
+      },
+      kind: SpanKind.client,
+      attributes: {'server.id': _server.id},
+    );
+  }
+
   void _startKeepalive() {
     if (!_keepaliveEnabled || _keepaliveTimer != null) {
       return;
@@ -862,11 +904,13 @@ class TrueNasApiClient implements ApiClientInterface {
   @override
   Future<List<App>> getAvailableApps() async {
     try {
-      await _ensureAuthenticated();
-      final result = await _client!.sendRequest('app.available');
-      return (result as List<dynamic>)
-          .map((app) => App.fromJson(app as Map<String, dynamic>))
-          .toList();
+      return await _traced('truenas.apps.available', () async {
+        await _ensureAuthenticated();
+        final result = await _client!.sendRequest('app.available');
+        return (result as List<dynamic>)
+            .map((app) => App.fromJson(app as Map<String, dynamic>))
+            .toList();
+      });
     } catch (e) {
       throw _handleError(e);
     }
@@ -875,11 +919,13 @@ class TrueNasApiClient implements ApiClientInterface {
   @override
   Future<List<App>> getInstalledApps() async {
     try {
-      await _ensureAuthenticated();
-      final result = await _client!.sendRequest('app.query');
-      return (result as List<dynamic>)
-          .map((app) => _convertTrueNasAppToApp(app as Map<String, dynamic>))
-          .toList();
+      return await _traced('truenas.apps.installed', () async {
+        await _ensureAuthenticated();
+        final result = await _client!.sendRequest('app.query');
+        return (result as List<dynamic>)
+            .map((app) => _convertTrueNasAppToApp(app as Map<String, dynamic>))
+            .toList();
+      });
     } catch (e) {
       throw _handleError(e);
     }
@@ -997,9 +1043,11 @@ class TrueNasApiClient implements ApiClientInterface {
   @override
   Future<List<String>> getAppCategories() async {
     try {
-      await _ensureAuthenticated();
-      final result = await _client!.sendRequest('app.categories');
-      return (result as List<dynamic>).cast<String>();
+      return await _traced('truenas.apps.categories', () async {
+        await _ensureAuthenticated();
+        final result = await _client!.sendRequest('app.categories');
+        return (result as List<dynamic>).cast<String>();
+      });
     } catch (e) {
       throw _handleError(e);
     }

--- a/test/models/app_test.dart
+++ b/test/models/app_test.dart
@@ -665,6 +665,54 @@ void main() {
       expect(usage.lastUpdated, isNull);
     });
 
+    // last_updated is the same kind of TrueNAS-supplied datetime as App's
+    // last_update, which has drifted across SCALE versions between
+    // Mongo-style extended JSON, a raw epoch number, and an ISO 8601 string
+    // (see the `App` group's last_update tests below). It must be parsed
+    // just as defensively instead of assuming a String, or a server on an
+    // unexpected shape throws a raw type error out of fromJson.
+    test('fromJson parses last_updated from a Mongo-style \$date payload', () {
+      final usage = AppResourceUsage.fromJson({
+        'last_updated': {'\$date': 1700000000000},
+      });
+
+      expect(
+        usage.lastUpdated,
+        equals(DateTime.fromMillisecondsSinceEpoch(1700000000000)),
+      );
+    });
+
+    test(
+      'fromJson parses last_updated from a raw epoch-millisecond number',
+      () {
+        final usage = AppResourceUsage.fromJson({
+          'last_updated': 1700000000000,
+        });
+
+        expect(
+          usage.lastUpdated,
+          equals(DateTime.fromMillisecondsSinceEpoch(1700000000000)),
+        );
+      },
+    );
+
+    test(
+      'fromJson tolerates an unrecognized last_updated shape instead of throwing',
+      () {
+        expect(
+          () => AppResourceUsage.fromJson({
+            'last_updated': ['not', 'a', 'date'],
+          }),
+          returnsNormally,
+        );
+
+        final usage = AppResourceUsage.fromJson({
+          'last_updated': ['not', 'a', 'date'],
+        });
+        expect(usage.lastUpdated, isNull);
+      },
+    );
+
     test('toJson round-trips', () {
       final usage = AppResourceUsage.fromJson({
         'cpu_usage': 1.0,

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -803,5 +803,66 @@ void main() {
       await client.getCurrentUser();
       expect(client.isKeepaliveActive, isTrue);
     });
+
+    test('getAvailableApps produces a truenas.apps.available span with '
+        'StatusCode.ok', () async {
+      server.onMethod(
+        'app.available',
+        (_) => [
+          {'name': 'plex', 'title': 'Plex'},
+        ],
+      );
+
+      final telemetry = FakeTelemetryService();
+      final client = TrueNasApiClient(testServer, null, telemetry);
+      addTearDown(client.close);
+
+      await client.getAvailableApps();
+
+      final span = telemetry.spans.singleWhere(
+        (s) => s.name == 'truenas.apps.available',
+      );
+      expect(span.kind, SpanKind.client);
+      expect(span.attributes['server.id'], testServer.id);
+      expect(span.status, StatusCode.ok);
+      expect(span.isEnded, isTrue);
+    });
+
+    test(
+      'a response that fails to parse produces an error span and logs the '
+      'failure, instead of surfacing only as a generic connection error '
+      'with no diagnostic trail - this is the gap that let two separate '
+      "TrueNAS response-shape bugs (App.last_update, then "
+      'AppResourceUsage.last_updated) go unnoticed by the connect-only span',
+      () async {
+        server.onMethod(
+          'app.available',
+          // 'maintainers' entries are expected to be maps (see
+          // AppMaintainer.fromJson); a string here reproduces the same
+          // "unexpected response shape" class of failure as the
+          // last_update/last_updated bugs.
+          (_) => [
+            {
+              'name': 'plex',
+              'maintainers': ['not-a-map'],
+            },
+          ],
+        );
+
+        final telemetry = FakeTelemetryService();
+        final client = TrueNasApiClient(testServer, null, telemetry);
+        addTearDown(client.close);
+
+        await expectLater(client.getAvailableApps(), throwsException);
+
+        final span = telemetry.spans.singleWhere(
+          (s) => s.name == 'truenas.apps.available',
+        );
+        expect(span.status, StatusCode.error);
+        expect(span.exceptions, isNotEmpty);
+        expect(span.isEnded, isTrue);
+        expect(telemetry.loggerNames, isNotEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
## What was wrong

#139 fixed `App.last_update` parsing to tolerate the several datetime shapes TrueNAS returns across SCALE versions (Mongo-style `{"$date": ...}` extended JSON, a raw epoch-millisecond number, or an ISO 8601 string) instead of assuming one fixed shape and throwing a raw type error out of `App.fromJson`.

`AppResourceUsage.last_updated` is the same kind of TrueNAS-supplied datetime, reachable from the same `App.fromJson` call site via the `resource_usage` field, but was still parsed the old unguarded way (`json['last_updated'] as String`). A server returning it in any shape other than a `String` still throws, and the app list still fails to load with the same generic "Connection error" the earlier fix was meant to eliminate.

Separately: the `truenas.connect` OTel span (#144) was added specifically to diagnose these "failed to load apps" reports, but it only wraps establishing the socket and authenticating. `getAvailableApps()`, `getInstalledApps()`, and `getAppCategories()` - where the actual response parsing happens, and where both this bug and the original `last_update` bug actually threw - ran entirely outside it. A parse failure there connects and authenticates fine, then throws with no span and no log record, so the instrumentation added to catch this bug class was structurally unable to see it.

I don't have a confirmed repro for the specific report that prompted this branch (no error text or server response was available) - this closes the same class of defect and the observability gap around it, not a verified root cause.

## What changed

- `lib/models/app.dart`: extracted the defensive datetime parsing into a shared `_parseTrueNasDate` helper, used by both `App.last_update` and `AppResourceUsage.last_updated`.
- `lib/services/truenas_api_client.dart`: added a `_traced()` helper (same span-plus-logged-exception shape as `_ensureConnectedTraced`) and wrapped `getAvailableApps()`, `getInstalledApps()`, and `getAppCategories()` with it (`truenas.apps.available`, `truenas.apps.installed`, `truenas.apps.categories`). A parse failure now produces an error span with the exception attached and a logged error, instead of only the generic "Connection error" label.
- Tests: regression tests for the Mongo-style, raw-epoch, and unrecognized-shape cases on `AppResourceUsage.last_updated` (mirroring the existing `App.last_update` tests), plus tests proving the new spans fire on both success and a parse failure.

## Verification

Set up Flutter 3.47.2 locally (matching CI) and ran:
- `flutter analyze` - no issues
- `flutter test` - full suite (1057 tests) passing, including the new regression and telemetry tests
- `dart format` - clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJYMyWPbW3q1MAY1LJVPk6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TrueNAS date values across supported formats.
  * Invalid or unsupported date values now safely return no date instead of causing errors.
  * Enhanced error reporting for app-related API requests while preserving existing error behavior.

* **Monitoring**
  * Added telemetry for available, installed, and categorized app requests, including success and failure details.

* **Tests**
  * Added coverage for date parsing and API telemetry success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->