### PR TITLE
fix: harden session recovery and close() against races found in review

### DIFF
--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -100,6 +100,11 @@ class TrueNasApiClient implements ApiClientInterface {
   /// In-flight authentication attempt, same coalescing as [_connecting].
   final _authenticating = _InFlight();
 
+  /// Set for good once [close] starts. Recovery triggers (keepalive timeout,
+  /// app-resume hook) check it so they cannot rebuild the session close is
+  /// tearing down; on-demand requests keep their reconnect behaviour.
+  bool _isClosing = false;
+
   Future<void> _ensureConnected() {
     if (_hasLiveConnection) {
       return Future.value();
@@ -368,6 +373,7 @@ class TrueNasApiClient implements ApiClientInterface {
   final _recovery = _InFlight();
 
   Future<void> _handleKeepaliveTimeout() {
+    if (_isClosing) return Future.value();
     return _recovery.run(_recoverConnection);
   }
 
@@ -394,6 +400,12 @@ class TrueNasApiClient implements ApiClientInterface {
     _jobsSubscriptionId = null;
 
     try {
+      // The session this recovery was invoked for is no longer trusted, even
+      // when its Peer hasn't noticed the death yet (a timed-out ping on a
+      // zombie socket leaves isClosed false). Only a login that completes
+      // during the settle below may vouch for the session again.
+      _isAuthenticated = false;
+
       // A connect or login already in flight is building the fresh session
       // this recovery wants. Let it settle instead of closing its socket
       // mid-handshake - tearing down here would kill the handshake, and
@@ -404,9 +416,15 @@ class TrueNasApiClient implements ApiClientInterface {
       if (!(_hasLiveConnection && _isAuthenticated)) {
         _isAuthenticated = false;
 
-        // Close existing connection
-        await _client?.close();
-        await _wsChannel?.sink.close();
+        // Detach and close only the stale session: awaiting a close yields,
+        // and a concurrent request may assign a fresh channel to these
+        // fields in the meantime - that one must survive.
+        final staleClient = _client;
+        final staleChannel = _wsChannel;
+        _client = null;
+        _wsChannel = null;
+        await staleClient?.close();
+        await staleChannel?.sink.close();
 
         // Re-establish connection
         await _ensureConnected();
@@ -451,6 +469,9 @@ class TrueNasApiClient implements ApiClientInterface {
 
   @override
   Future<void> ensureConnectionAlive() async {
+    // A closing client has nothing to keep alive.
+    if (_isClosing) return;
+
     // _sendKeepalivePing already owns the "is this connection usable, and
     // recover it if not" decision; don't restate it here.
     await _sendKeepalivePing();
@@ -668,10 +689,17 @@ class TrueNasApiClient implements ApiClientInterface {
 
   @override
   Future<void> close() async {
-    // Let an in-flight connect or login settle first, so this close tears
-    // down the socket that attempt produces instead of racing its handshake
-    // - which would leak the socket and the keepalive timer a successful
-    // login starts.
+    // Refuse recovery work from here on: a keepalive timeout or app-resume
+    // hook firing during the awaits below must not rebuild the session this
+    // close is tearing down. Set before the first await so nothing sneaks
+    // in between.
+    _isClosing = true;
+
+    // Let in-flight work settle first, so this close tears down the socket
+    // those attempts produce instead of racing their handshakes - which
+    // would leak the socket and the keepalive timer a successful login
+    // starts.
+    await _recovery.settle();
     await _connecting.settle();
     await _authenticating.settle();
 
@@ -683,11 +711,13 @@ class TrueNasApiClient implements ApiClientInterface {
     await unsubscribeFromSystemStats();
     await unsubscribeFromAppStats();
     await unsubscribeFromJobs();
-    await _client?.close();
-    await _wsChannel?.sink.close();
+    final staleClient = _client;
+    final staleChannel = _wsChannel;
     _client = null;
     _wsChannel = null;
     _isAuthenticated = false;
+    await staleClient?.close();
+    await staleChannel?.sink.close();
   }
 
   // Authentication methods

--- a/test/services/connection_recovery_test.dart
+++ b/test/services/connection_recovery_test.dart
@@ -26,6 +26,10 @@ class FakeTrueNasServer {
   /// subscriptions for a while after a reconnect.
   bool failSubscribes = false;
 
+  /// Makes core.ping hang forever, the way a half-dead socket behaves: the
+  /// TCP connection looks open, but nothing ever comes back.
+  bool hangPings = false;
+
   static Future<FakeTrueNasServer> start() async {
     final httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     final server = FakeTrueNasServer._(httpServer);
@@ -61,6 +65,7 @@ class FakeTrueNasServer {
       })
       ..registerMethod('core.unsubscribe', (json_rpc.Parameters _) => true)
       ..registerMethod('core.ping', (json_rpc.Parameters _) {
+        if (hangPings) return Completer<String>().future;
         pingCount++;
         return 'pong';
       });
@@ -208,6 +213,49 @@ void main() {
         client.ensureConnectionAlive(),
         throwsA(isA<Exception>()),
       );
+    },
+  );
+
+  test('a zombie socket that stops answering pings is torn down and '
+      're-authenticated', () async {
+    await client.subscribeToSystemStats();
+    expect(server.loginCount, 1);
+
+    // The socket stays open but stops answering - a half-dead connection
+    // the Peer cannot see (isClosed remains false), so recovery must not
+    // trust the session just because the socket still looks live.
+    server.hangPings = true;
+    unawaited(client.ensureConnectionAlive().catchError((_) {}));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    // The next resume finds the earlier ping still unanswered and has to
+    // recover with a fresh session, not vouch for the zombie.
+    server.hangPings = false;
+    await client.ensureConnectionAlive();
+
+    expect(
+      server.loginCount,
+      2,
+      reason:
+          'recovery must re-authenticate on a fresh socket instead of '
+          'reporting the unresponsive session as connected',
+    );
+  });
+
+  test(
+    'close() prevents later recovery from resurrecting the session',
+    () async {
+      await client.subscribeToSystemStats();
+      expect(server.loginCount, 1);
+
+      await client.close();
+
+      // The app-resume hook can still fire for a client that was just
+      // released; it must not rebuild the session close tore down, which
+      // would leak a socket and a keepalive timer nobody owns.
+      await client.ensureConnectionAlive();
+
+      expect(server.loginCount, 1, reason: 'a closed client must stay closed');
     },
   );
 


### PR DESCRIPTION
## Problem

CodeRabbit's review of #147 (merged before the findings were addressed) identified three real races in the new `_InFlight` session coalescing:

1. **Zombie sessions survived recovery.** A keepalive timeout can fire while `Peer.isClosed` is still false, so `_hasLiveConnection && _isAuthenticated` stayed true and recovery skipped the reconnect it was invoked for, reporting the dead session as connected.
2. **Teardown could close the wrong socket.** `await _client?.close()` yields; a concurrent request could assign a fresh channel to `_wsChannel`, which the next teardown line then closed.
3. **Recovery could resurrect a closed client.** `close()` settled the connect/login latches but not `_recovery`, and set no gate — a keepalive timeout or app-resume hook firing during close could rebuild the session afterward, leaking the socket and its keepalive timer.

## Approach

- Recovery clears `_isAuthenticated` before the latches settle — only a login completing during the settle can vouch for the session again.
- Recovery and `close()` detach `_client`/`_wsChannel` before awaiting their close, so only the captured stale instances are torn down.
- `close()` sets an `_isClosing` gate before its first await and settles a running `_recovery`; the keepalive-timeout and app-resume paths check the gate. On-demand requests keep their reconnect behaviour.

## Tests

Two new regression tests against the fake WebSocket middleware, both red before the fix:
- a zombie socket that stops answering pings is torn down and re-authenticated (asserts a second login);
- `close()` prevents later recovery from resurrecting the session (asserts no second login).

Full suite: 1060 tests green.

https://claude.ai/code/session_01UD3rn9Cj74zuAdYELDGHNG