### PR TITLE
fix: enable automatic dark mode by following system brightness

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -197,7 +197,6 @@ class _TrueNASManagerAppState extends State<TrueNASManagerApp> {
         title: 'TrueNAS Manager',
         theme: const CupertinoThemeData(
           primaryColor: CupertinoColors.systemBlue,
-          brightness: Brightness.light,
         ),
         routerConfig: appRouter,
       ),


### PR DESCRIPTION
CupertinoThemeData was pinned to Brightness.light, forcing light mode
regardless of the OS setting. Leaving brightness unset lets Cupertino
resolve it from MediaQuery.platformBrightness so the app follows the
system's light/dark appearance automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the app’s visual theme configuration to use the default brightness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->