### PR TITLE
fix(release): pass OTLP secrets to the TestFlight build so telemetry is enabled

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,6 +110,13 @@ jobs:
           MATCH_GIT_URL:                         ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD:                        ${{ secrets.MATCH_PASSWORD }}
           MATCH_KEYCHAIN_PASSWORD:               ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          # Telemetry. fastlane's telemetry_dart_defines turns these into the
+          # flutter_otel --dart-define flags; either one missing or blank
+          # leaves telemetry disabled for the build (never fails it). Without
+          # this block the 0.4.2 TestFlight build shipped with telemetry off
+          # because the secrets never reached the step's environment.
+          OTLP_INGEST_URL:                       ${{ secrets.OTLP_INGEST_URL }}
+          OTLP_INGEST_KEY:                       ${{ secrets.OTLP_INGEST_KEY }}
           FASTLANE_HIDE_CHANGELOG:               "true"
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT:  "120"
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES:  "5"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -148,8 +148,16 @@ def telemetry_dart_defines
   endpoint = env.call("OTLP_INGEST_URL")
   api_key  = env.call("OTLP_INGEST_KEY")
 
-  return [] if endpoint.nil? || api_key.nil?
+  if endpoint.nil? || api_key.nil?
+    UI.important(
+      "Telemetry disabled: OTLP_INGEST_URL and/or OTLP_INGEST_KEY not set " \
+      "(url: #{endpoint.nil? ? 'missing' : 'set'}, key: #{api_key.nil? ? 'missing' : 'set'})"
+    )
+    return []
+  end
 
+  # Log the endpoint, never the key.
+  UI.message("Telemetry enabled: exporting OTLP to #{endpoint}")
   headers = "authorization=Bearer #{api_key},x-tenant-id=homelab,x-dataset-id=apps"
 
   [

--- a/scripts/bootstrap-release-secrets.sh
+++ b/scripts/bootstrap-release-secrets.sh
@@ -60,6 +60,15 @@ set_secret MATCH_PASSWORD "$MATCH_PASSWORD"
 set_secret MATCH_KEYCHAIN_PASSWORD "$(openssl rand -base64 32)"
 set_secret MATCH_DEPLOY_KEY "$(cat "$tmp/key")"
 
+# Optional: SignalDB OTLP ingest for flutter_otel (see fastlane/.env.default).
+# Both must be present for the release build to enable telemetry.
+if [[ -n "${OTLP_INGEST_URL:-}" && -n "${OTLP_INGEST_KEY:-}" ]]; then
+  set_secret OTLP_INGEST_URL "$OTLP_INGEST_URL"
+  set_secret OTLP_INGEST_KEY "$OTLP_INGEST_KEY"
+else
+  echo "  skipped OTLP_INGEST_URL/OTLP_INGEST_KEY (export both to set them)"
+fi
+
 # Same override precedence as fastlane/Appfile.
 # ${VAR-...} (no colon) mirrors the Appfile's Ruby `ENV[..] ||` semantics,
 # which keeps a set-but-empty value.
@@ -67,7 +76,7 @@ EFFECTIVE_APP_ID="${APP_IDENTIFIER-$(grep -o 'com\.cedricziel\.[A-Za-z0-9.]*' fa
 
 cat <<MSG
 
-Done. Two manual steps remain:
+Done. Manual steps remaining:
 
 1. RELEASE_PLEASE_TOKEN: a fine-grained PAT with Contents + Pull requests
    (read/write) on $REPO, so the release PR triggers CI:
@@ -77,4 +86,9 @@ Done. Two manual steps remain:
    App ID $EFFECTIVE_APP_ID to exist with its capabilities enabled):
      cp fastlane/.env.default fastlane/.env   # fill in ASC_* and MATCH_PASSWORD
      bundle exec fastlane bootstrap_signing
+
+3. Telemetry (optional, skipped above unless both were exported): the
+   release build only exports OTLP when both secrets exist:
+     gh secret set OTLP_INGEST_URL --repo $REPO
+     gh secret set OTLP_INGEST_KEY --repo $REPO
 MSG

--- a/scripts/otel_smoke.sh
+++ b/scripts/otel_smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Sends one OTLP/JSON log record and one span to an OTLP/HTTP endpoint using
+# the exact wire format flutter_otel's OtlpHttpLogExporter / OtlpHttpSpanExporter
+# produce (JSON protobuf mapping, hex trace/span ids, nanos as strings, intValue
+# as string). Lets you validate an ingest endpoint + headers with nothing but
+# curl, independent of building the app.
+#
+# Usage (same env vars the app reads via --dart-define):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.example/otlp \
+#   OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer KEY,x-tenant-id=homelab,x-dataset-id=apps" \
+#   OTEL_SERVICE_NAME=truehub OTEL_DEPLOYMENT_ENVIRONMENT=smoke \
+#   scripts/otel_smoke.sh
+#
+# Exit code is non-zero if either signal gets a non-2xx response. The run id
+# printed at the end is stamped on both the log record and the span as
+# `smoke.run_id`, so you can search for it in the backend.
+set -euo pipefail
+
+endpoint="${OTEL_EXPORTER_OTLP_ENDPOINT:?set OTEL_EXPORTER_OTLP_ENDPOINT}"
+raw_headers="${OTEL_EXPORTER_OTLP_HEADERS:-}"
+service_name="${OTEL_SERVICE_NAME:-truehub}"
+environment="${OTEL_DEPLOYMENT_ENVIRONMENT:-smoke}"
+
+# Mirror TelemetryConfig.parseHeaders: split on ',', then on the first '='.
+header_args=()
+IFS=',' read -r -a pairs <<<"$raw_headers"
+for pair in "${pairs[@]}"; do
+  pair="$(echo "$pair" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  [[ -z "$pair" || "$pair" != *=* ]] && continue
+  key="${pair%%=*}"; value="${pair#*=}"
+  [[ -z "$key" ]] && continue
+  header_args+=(-H "$key: $value")
+done
+
+# Mirror resolveLogsEndpoint/resolveTracesEndpoint: strip one trailing '/'.
+base="${endpoint%/}"
+logs_url="$base/v1/logs"
+traces_url="$base/v1/traces"
+
+rand_hex() { head -c "$1" /dev/urandom | xxd -p | tr -d '\n'; }
+trace_id="$(rand_hex 16)"
+span_id="$(rand_hex 8)"
+run_id="$(rand_hex 6)"
+now_ns="$(python3 -c 'import time; print(time.time_ns())')"
+start_ns=$((now_ns - 250000000))
+
+resource_attrs=$(cat <<JSON
+[{"key":"service.name","value":{"stringValue":"$service_name"}},
+ {"key":"deployment.environment","value":{"stringValue":"$environment"}}]
+JSON
+)
+
+log_body=$(cat <<JSON
+{"resourceLogs":[{"resource":{"attributes":$resource_attrs},
+ "scopeLogs":[{"scope":{"name":"truehub"},
+ "logRecords":[{"timeUnixNano":"$now_ns","observedTimeUnixNano":"$now_ns",
+  "severityNumber":17,"severityText":"ERROR",
+  "body":{"stringValue":"otel smoke test log (run $run_id)"},
+  "attributes":[{"key":"smoke.run_id","value":{"stringValue":"$run_id"}},
+                {"key":"exception.type","value":{"stringValue":"SmokeTestException"}},
+                {"key":"attempt","value":{"intValue":"1"}},
+                {"key":"server.network.trusted","value":{"boolValue":true}}],
+  "traceId":"$trace_id","spanId":"$span_id"}]}]}]}
+JSON
+)
+
+trace_body=$(cat <<JSON
+{"resourceSpans":[{"resource":{"attributes":$resource_attrs},
+ "scopeSpans":[{"scope":{"name":"truehub"},
+ "spans":[{"traceId":"$trace_id","spanId":"$span_id","name":"truenas.connect",
+  "kind":3,"startTimeUnixNano":"$start_ns","endTimeUnixNano":"$now_ns",
+  "attributes":[{"key":"smoke.run_id","value":{"stringValue":"$run_id"}},
+                {"key":"server.id","value":{"stringValue":"smoke-server"}}],
+  "events":[{"timeUnixNano":"$now_ns","name":"exception",
+    "attributes":[{"key":"exception.message","value":{"stringValue":"smoke"}}]}],
+  "status":{"code":2,"message":"smoke failure"}}]}]}]}
+JSON
+)
+
+post() {
+  local label="$1" url="$2" body="$3"
+  local tmp; tmp="$(mktemp)"
+  local status
+  status="$(curl -sS -o "$tmp" -w '%{http_code}' -X POST "$url" \
+    -H 'Content-Type: application/json' "${header_args[@]}" --data "$body" || echo "000")"
+  printf '%-7s %s -> HTTP %s\n' "$label" "$url" "$status"
+  if [[ -s "$tmp" ]]; then printf '        body: %s\n' "$(head -c 500 "$tmp")"; fi
+  rm -f "$tmp"
+  [[ "$status" =~ ^2 ]]
+}
+
+ok=0
+post logs   "$logs_url"   "$log_body"   || ok=1
+post traces "$traces_url" "$trace_body" || ok=1
+echo "run_id=$run_id trace_id=$trace_id"
+exit $ok


### PR DESCRIPTION
## Summary

- The `testflight` job never exported `OTLP_INGEST_URL` / `OTLP_INGEST_KEY` into the fastlane step, so `telemetry_dart_defines` returned `[]` and the 0.4.2 build shipped with flutter_otel compiled off (the 0.4.2 run log shows `flutter build ios` with no `--dart-define`s). Wire the secrets through.
- fastlane now logs `Telemetry enabled: exporting OTLP to <url>` or `Telemetry disabled: ...` (endpoint only, never the key) so the build log answers this at a glance.
- `scripts/bootstrap-release-secrets.sh` sets both secrets when exported and lists them as a manual step otherwise.
- New `scripts/otel_smoke.sh`: a curl replay of the exact OTLP/JSON shape `OtlpHttpLogExporter` / `OtlpHttpSpanExporter` produce, driven by the same `OTEL_*` env vars the app reads, for validating an ingest endpoint without building the app.

## Validation

- Smoke script against the SignalDB ingest: `/v1/logs` and `/v1/traces` both 200, records confirmed visible in the backend.
- Endpoint rejects wrong key (401), missing tenant (401), wrong dataset (403) and malformed OTLP/JSON (400), so a 200 is meaningful.
- Exporter edge cases accepted: empty `AnyValue` for null attributes, nested arrays, no trace context, 62 KB stack trace attribute, full 512-record batch, child spans with unset status.
- Both secrets are now set on the repo; the next release build will export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TestFlight builds can now receive optional telemetry endpoint and authentication settings.
  * Release setup can configure telemetry secrets when provided.

* **Improvements**
  * Telemetry configuration now reports whether it is enabled or disabled while keeping authentication keys private.
  * Added a utility to verify log and trace delivery, including endpoint responses and correlation IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->