### PR TITLE
fix: load apps reliably over slow links and surface the real error instead of "Connection error"

### DIFF
--- a/lib/models/connection_error.dart
+++ b/lib/models/connection_error.dart
@@ -5,6 +5,7 @@ enum ConnectionErrorType {
   invalidCredentials,
   serverError,
   permissionDenied,
+  invalidResponse,
   unknown,
 }
 
@@ -75,6 +76,19 @@ class ConnectionError {
     );
   }
 
+  /// The server answered, but with data this app could not read - a
+  /// response-shape mismatch between TrueNAS versions, or a parsing bug on
+  /// our side. Distinct from [ConnectionError.unknown] so it never shows up
+  /// as a generic "Connection error" that hides the actual cause.
+  factory ConnectionError.invalidResponse({String? details}) {
+    return ConnectionError(
+      type: ConnectionErrorType.invalidResponse,
+      message: 'Unexpected response from server',
+      technicalDetails: details,
+      isRetryable: true,
+    );
+  }
+
   factory ConnectionError.unknown({String? details}) {
     return ConnectionError(
       type: ConnectionErrorType.unknown,
@@ -116,6 +130,11 @@ class ConnectionError {
             '• User account permissions\n'
             '• Account is active\n'
             '• Required roles are assigned';
+      case ConnectionErrorType.invalidResponse:
+        return 'The server sent data this app could not read. Please:\n'
+            '• Update TrueNAS Manager to the latest version\n'
+            '• Check the TrueNAS version is supported\n'
+            '• Report the issue with the technical details';
       case ConnectionErrorType.unknown:
         return 'An unexpected error occurred. Please:\n'
             '• Try again\n'
@@ -138,6 +157,8 @@ class ConnectionError {
         return 'Server error';
       case ConnectionErrorType.permissionDenied:
         return 'Permission denied';
+      case ConnectionErrorType.invalidResponse:
+        return 'Unexpected server response';
       case ConnectionErrorType.unknown:
         return 'Connection error';
     }

--- a/lib/providers/app_provider.dart
+++ b/lib/providers/app_provider.dart
@@ -11,6 +11,15 @@ import 'package:truehub/services/database.dart';
 import 'package:truehub/services/unified_server_service.dart';
 import 'package:truehub/providers/server_provider.dart';
 
+/// The result of a settled future: exactly one of [value] or [error] is set.
+class _Outcome<T> {
+  final T? value;
+  final Object? error;
+
+  const _Outcome.success(this.value) : error = null;
+  const _Outcome.failure(this.error) : value = null;
+}
+
 class AppProvider extends ChangeNotifier {
   final AppDatabase Function() _databaseRef;
   final UnifiedServerService _serverService;
@@ -21,6 +30,7 @@ class AppProvider extends ChangeNotifier {
   List<String> _categories = [];
   bool _isLoading = false;
   ConnectionError? _connectionError;
+  ConnectionError? _catalogError;
   StreamSubscription<Map<String, AppResourceUsage>>? _appStatsSubscription;
   final Map<String, AppResourceUsage> _lastKnownResourceUsage = {};
 
@@ -50,6 +60,18 @@ class AppProvider extends ChangeNotifier {
   ConnectionError? get connectionError => _connectionError;
   String? get error => _connectionError?.shortMessage;
 
+  /// The underlying cause of [error], when known - e.g. the middleware's
+  /// reason text or the parse failure - for showing alongside the short
+  /// message so a failure can actually be diagnosed from the screen.
+  String? get errorDetails => _connectionError?.technicalDetails;
+
+  /// Set when the installed apps loaded fine but the catalog side
+  /// (`app.available` / `app.categories`) failed. The load is then only
+  /// degraded, not failed: installed apps stay usable and any previously
+  /// synced catalog entries remain visible, so this is surfaced per-tab
+  /// rather than as [connectionError].
+  ConnectionError? get catalogError => _catalogError;
+
   List<AppConfig> get installedApps =>
       _appConfigs.where((app) => app.installed == true).toList();
   List<AppConfig> get availableApps =>
@@ -74,6 +96,7 @@ class AppProvider extends ChangeNotifier {
     _appConfigs = [];
     _categories = [];
     _connectionError = null;
+    _catalogError = null;
 
     if (server != null) {
       try {
@@ -114,6 +137,7 @@ class AppProvider extends ChangeNotifier {
     _appConfigs = [];
     _categories = [];
     _connectionError = null;
+    _catalogError = null;
 
     try {
       // Load credentials for the server
@@ -148,6 +172,7 @@ class AppProvider extends ChangeNotifier {
 
     _isLoading = true;
     _connectionError = null;
+    _catalogError = null;
     notifyListeners();
 
     try {
@@ -186,16 +211,39 @@ class AppProvider extends ChangeNotifier {
   Future<void> _loadAppsOnline() async {
     if (_apiClient == null || _currentServerId == null) return;
 
-    // Load available apps, installed apps, and categories in parallel
-    final results = await Future.wait([
-      _apiClient!.getAvailableApps(),
-      _apiClient!.getInstalledApps(),
-      _apiClient!.getAppCategories(),
-    ]);
+    // Load installed apps, available apps, and categories in parallel.
+    //
+    // Installed apps (`app.query`) are the essential part - if that fails
+    // the load fails. The catalog calls are allowed to fail on their own:
+    // `app.available` is by far the biggest and slowest response (the full
+    // catalog, readmes included) and depends on the NAS having synced its
+    // catalog, so a problem there must not hide the user's installed apps.
+    final installedFuture = _apiClient!.getInstalledApps();
+    final availableFuture = _settle(_apiClient!.getAvailableApps());
+    final categoriesFuture = _settle(_apiClient!.getAppCategories());
 
-    final availableApps = results[0] as List<App>;
-    final installedApps = results[1] as List<App>;
-    _categories = results[2] as List<String>;
+    // Await the settled catalog futures too, so their outcomes are consumed
+    // (never left as unhandled async errors) even when the installed call
+    // throws first.
+    final installedApps = await installedFuture;
+    final available = await availableFuture;
+    final categories = await categoriesFuture;
+
+    final availableApps = available.value ?? const <App>[];
+    if (categories.value != null) {
+      _categories = categories.value!;
+    }
+
+    final catalogFailure = available.error ?? categories.error;
+    if (catalogFailure != null) {
+      _catalogError = _toConnectionError(catalogFailure);
+      if (kDebugMode) {
+        print(
+          'AppProvider: catalog load failed, continuing with installed apps: '
+          '${_catalogError!.technicalDetails ?? _catalogError!.message}',
+        );
+      }
+    }
 
     // Merge installed and available apps, prioritizing installed app data
     final allApps = <String, App>{};
@@ -221,6 +269,17 @@ class AppProvider extends ChangeNotifier {
         'AppProvider: Synced ${allApps.length} apps to database (${installedApps.length} installed, ${availableApps.length} available)',
       );
     }
+  }
+
+  /// Turns [future] into one that never fails, capturing its outcome as an
+  /// [_Outcome] instead.
+  Future<_Outcome<T>> _settle<T>(Future<T> future) => future
+      .then<_Outcome<T>>(_Outcome.success)
+      .catchError((Object e) => _Outcome<T>.failure(e));
+
+  ConnectionError _toConnectionError(Object error) {
+    if (error is ConnectionException) return error.error;
+    return ConnectionError.unknown(details: error.toString());
   }
 
   Future<void> _syncAppsToDatabase(List<App> apps) async {

--- a/lib/providers/app_provider.dart
+++ b/lib/providers/app_provider.dart
@@ -20,6 +20,13 @@ class _Outcome<T> {
   const _Outcome.failure(this.error) : value = null;
 }
 
+/// The catalog side of a load, started alongside the installed-apps request
+/// and merged in a second phase once installed apps are already visible.
+typedef _CatalogRequests = ({
+  Future<_Outcome<List<App>>> available,
+  Future<_Outcome<List<String>>> categories,
+});
+
 class AppProvider extends ChangeNotifier {
   final AppDatabase Function() _databaseRef;
   final UnifiedServerService _serverService;
@@ -29,8 +36,13 @@ class AppProvider extends ChangeNotifier {
   List<AppConfig> _appConfigs = [];
   List<String> _categories = [];
   bool _isLoading = false;
+  bool _isCatalogLoading = false;
   ConnectionError? _connectionError;
   ConnectionError? _catalogError;
+
+  /// Bumped by every load, server switch and dispose, so a catalog phase
+  /// that finishes late can tell it no longer belongs to the current state.
+  int _loadGeneration = 0;
   StreamSubscription<Map<String, AppResourceUsage>>? _appStatsSubscription;
   final Map<String, AppResourceUsage> _lastKnownResourceUsage = {};
 
@@ -57,6 +69,11 @@ class AppProvider extends ChangeNotifier {
   List<AppConfig> get appConfigs => _appConfigs;
   List<String> get categories => _categories;
   bool get isLoading => _isLoading;
+
+  /// True while the catalog (`app.available` / `app.categories`) is still
+  /// being fetched or merged after the installed apps are already loaded.
+  bool get isCatalogLoading => _isCatalogLoading;
+
   ConnectionError? get connectionError => _connectionError;
   String? get error => _connectionError?.shortMessage;
 
@@ -90,6 +107,7 @@ class AppProvider extends ChangeNotifier {
       await ApiClientManager.releaseClient(_currentServerId!);
     }
 
+    _loadGeneration++;
     _currentServerId = server?.id;
     _currentServer = server;
     _apiClient = null;
@@ -97,6 +115,7 @@ class AppProvider extends ChangeNotifier {
     _categories = [];
     _connectionError = null;
     _catalogError = null;
+    _isCatalogLoading = false;
 
     if (server != null) {
       try {
@@ -132,12 +151,14 @@ class AppProvider extends ChangeNotifier {
       await ApiClientManager.releaseClient(_currentServerId!);
     }
 
+    _loadGeneration++;
     _currentServerId = server.id;
     _currentServer = server;
     _appConfigs = [];
     _categories = [];
     _connectionError = null;
     _catalogError = null;
+    _isCatalogLoading = false;
 
     try {
       // Load credentials for the server
@@ -169,24 +190,36 @@ class AppProvider extends ChangeNotifier {
 
   Future<void> loadApps() async {
     if (_currentServerId == null) return;
+    final generation = ++_loadGeneration;
 
     _isLoading = true;
+    _isCatalogLoading = false;
     _connectionError = null;
     _catalogError = null;
     notifyListeners();
 
+    // The catalog requests are fired alongside the installed-apps request
+    // but merged in a second phase (see [_loadCatalog]), so installed apps
+    // are shown the moment they arrive. `app.available` is by far the
+    // biggest and slowest response (the whole catalog, readmes included -
+    // megabytes over a cellular link) and must not hold the user's own apps
+    // hostage. Its failures are allowed too: installed apps (`app.query`)
+    // are the essential part, the catalog is not.
+    _CatalogRequests? catalog;
     try {
-      if (_apiClient != null) {
-        // Online mode: Load fresh data from API and sync to database
-        await _loadAppsOnline();
+      final apiClient = _apiClient;
+      if (apiClient != null) {
+        catalog = (
+          available: _settle(apiClient.getAvailableApps()),
+          categories: _settle(apiClient.getAppCategories()),
+        );
+        await _loadInstalledAppsOnline(apiClient);
+
+        // Subscribe to app stats for real-time resource usage
+        _subscribeToAppStats();
       } else {
         // Offline mode: Load from database only
         await _loadPersistedAppConfigs();
-      }
-
-      // Subscribe to app stats for real-time resource usage (if online)
-      if (_apiClient != null) {
-        _subscribeToAppStats();
       }
 
       // Clear any previous errors on successful load
@@ -206,68 +239,87 @@ class AppProvider extends ChangeNotifier {
       _isLoading = false;
       notifyListeners();
     }
+
+    // The catalog is only worth merging on top of a successful installed
+    // load. Its futures are settled, so leaving them behind leaks no error.
+    if (catalog != null && _connectionError == null) {
+      await _loadCatalog(generation, catalog);
+    }
   }
 
-  Future<void> _loadAppsOnline() async {
-    if (_apiClient == null || _currentServerId == null) return;
+  Future<void> _loadInstalledAppsOnline(ApiClientInterface apiClient) async {
+    final installedApps = await apiClient.getInstalledApps();
 
-    // Load installed apps, available apps, and categories in parallel.
-    //
-    // Installed apps (`app.query`) are the essential part - if that fails
-    // the load fails. The catalog calls are allowed to fail on their own:
-    // `app.available` is by far the biggest and slowest response (the full
-    // catalog, readmes included) and depends on the NAS having synced its
-    // catalog, so a problem there must not hide the user's installed apps.
-    final installedFuture = _apiClient!.getInstalledApps();
-    final availableFuture = _settle(_apiClient!.getAvailableApps());
-    final categoriesFuture = _settle(_apiClient!.getAppCategories());
-
-    // Await the settled catalog futures too, so their outcomes are consumed
-    // (never left as unhandled async errors) even when the installed call
-    // throws first.
-    final installedApps = await installedFuture;
-    final available = await availableFuture;
-    final categories = await categoriesFuture;
-
-    final availableApps = available.value ?? const <App>[];
-    if (categories.value != null) {
-      _categories = categories.value!;
-    }
-
-    final catalogFailure = available.error ?? categories.error;
-    if (catalogFailure != null) {
-      _catalogError = _toConnectionError(catalogFailure);
-      if (kDebugMode) {
-        print(
-          'AppProvider: catalog load failed, continuing with installed apps: '
-          '${_catalogError!.technicalDetails ?? _catalogError!.message}',
-        );
-      }
-    }
-
-    // Merge installed and available apps, prioritizing installed app data
-    final allApps = <String, App>{};
-
-    // Add available apps first
-    for (final app in availableApps) {
-      allApps[app.name] = app;
-    }
-
-    // Override with installed app data (which includes resource usage and upgrade info)
-    for (final app in installedApps) {
-      allApps[app.name] = app;
-    }
-
-    // Sync all app data to database as unified AppConfig records
-    await _syncAppsToDatabase(allApps.values.toList());
-
-    // Load the updated app configs from database (which now includes merged data)
+    await _syncAppsToDatabase(installedApps);
     await _loadPersistedAppConfigs();
 
     if (kDebugMode) {
       print(
-        'AppProvider: Synced ${allApps.length} apps to database (${installedApps.length} installed, ${availableApps.length} available)',
+        'AppProvider: Synced ${installedApps.length} installed apps to '
+        'database',
       );
+    }
+  }
+
+  /// Second phase of [loadApps]: waits for the catalog requests started
+  /// there and merges them on top of the already-synced installed apps.
+  /// [generation] identifies the load this belongs to - a server switch or
+  /// a newer load in the meantime makes this catalog stale, and it is then
+  /// dropped rather than merged into the wrong server's state.
+  Future<void> _loadCatalog(int generation, _CatalogRequests catalog) async {
+    _isCatalogLoading = true;
+    notifyListeners();
+
+    try {
+      final available = await catalog.available;
+      final categories = await catalog.categories;
+      if (generation != _loadGeneration) return;
+
+      if (categories.value != null) {
+        _categories = categories.value!;
+      }
+
+      final catalogFailure = available.error ?? categories.error;
+      if (catalogFailure != null) {
+        _catalogError = _toConnectionError(catalogFailure);
+        if (kDebugMode) {
+          print(
+            'AppProvider: catalog load failed, keeping installed apps: '
+            '${_catalogError!.technicalDetails ?? _catalogError!.message}',
+          );
+        }
+      }
+
+      // Installed apps were synced first and carry the richer data
+      // (resource usage, upgrade info, portals); the catalog only adds the
+      // apps that are not installed.
+      final installedNames = _appConfigs
+          .where((config) => config.installed == true)
+          .map((config) => config.appName)
+          .toSet();
+      final availableApps = (available.value ?? const <App>[])
+          .where((app) => !installedNames.contains(app.name))
+          .toList();
+
+      await _syncAppsToDatabase(availableApps);
+      if (generation != _loadGeneration) return;
+      await _loadPersistedAppConfigs();
+
+      if (kDebugMode) {
+        print(
+          'AppProvider: Synced ${availableApps.length} available apps to '
+          'database',
+        );
+      }
+    } catch (e) {
+      if (generation == _loadGeneration) {
+        _catalogError = _toConnectionError(e);
+      }
+    } finally {
+      if (generation == _loadGeneration) {
+        _isCatalogLoading = false;
+        notifyListeners();
+      }
     }
   }
 
@@ -696,6 +748,9 @@ class AppProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    // A catalog phase still in flight must not notify a disposed notifier.
+    _loadGeneration++;
+
     // Unsubscribe from app stats
     _unsubscribeFromAppStats();
 

--- a/lib/screens/server_apps_screen.dart
+++ b/lib/screens/server_apps_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/models/app.dart';
+import 'package:truehub/models/connection_error.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/widgets/app_card_widget.dart';
 import 'package:truehub/widgets/empty_state_widget.dart';
@@ -165,19 +166,39 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
                   }
 
                   if (appProvider.error != null) {
-                    return _buildErrorView(appProvider.error!);
+                    return _buildErrorView(
+                      title: 'Failed to load apps',
+                      error: appProvider.error!,
+                      details: appProvider.errorDetails,
+                    );
                   }
 
                   final apps = _getFilteredApps(appProvider);
+                  final catalogError = _selectedSegment == 1
+                      ? appProvider.catalogError
+                      : null;
 
                   if (apps.isEmpty) {
+                    if (catalogError != null) {
+                      return _buildErrorView(
+                        title: 'Failed to load app catalog',
+                        error: catalogError.shortMessage,
+                        details: catalogError.technicalDetails,
+                      );
+                    }
                     return _buildEmptyView();
                   }
 
                   return ListView.builder(
                     padding: const EdgeInsets.symmetric(horizontal: 16),
-                    itemCount: apps.length,
+                    itemCount: apps.length + (catalogError != null ? 1 : 0),
                     itemBuilder: (context, index) {
+                      if (catalogError != null) {
+                        if (index == 0) {
+                          return _buildCatalogNotice(catalogError);
+                        }
+                        index -= 1;
+                      }
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 12),
                         child: AppCardWidget(app: apps[index]),
@@ -239,13 +260,39 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
     return apps;
   }
 
-  Widget _buildErrorView(String error) {
+  Widget _buildErrorView({
+    required String title,
+    required String error,
+    String? details,
+  }) {
     return ErrorStateWidget(
-      title: 'Failed to load apps',
-      message: error,
+      title: title,
+      message: details == null ? error : '$error\n$details',
       onRetry: () {
         context.read<AppProvider>().refreshApps();
       },
+    );
+  }
+
+  /// Shown above a stale catalog list when the catalog could not be
+  /// refreshed this time, so the user knows the entries may be outdated
+  /// without losing them.
+  Widget _buildCatalogNotice(ConnectionError catalogError) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: CupertinoColors.systemYellow.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Text(
+          'Catalog could not be refreshed: ${catalogError.shortMessage}. '
+          'Showing the last synced apps.',
+          style: const TextStyle(fontSize: 13),
+        ),
+      ),
     );
   }
 

--- a/lib/screens/server_apps_screen.dart
+++ b/lib/screens/server_apps_screen.dart
@@ -179,7 +179,14 @@ class _ServerAppsScreenState extends State<ServerAppsScreen> {
                       : null;
 
                   if (apps.isEmpty) {
-                    if (catalogError != null) {
+                    if (_selectedSegment == 1 && appProvider.isCatalogLoading) {
+                      return const LoadingStateWidget(
+                        message: 'Loading app catalog...',
+                      );
+                    }
+                    // A search that matches nothing is still a search result,
+                    // even when the catalog it searched is stale.
+                    if (catalogError != null && _searchQuery.isEmpty) {
                       return _buildErrorView(
                         title: 'Failed to load app catalog',
                         error: catalogError.shortMessage,

--- a/lib/screens/server_detail_screen.dart
+++ b/lib/screens/server_detail_screen.dart
@@ -342,7 +342,10 @@ class _ServerDetailScreenState extends State<ServerDetailScreen> {
               else if (appProvider.error != null)
                 ErrorStateWidget(
                   title: 'App Error',
-                  message: 'Failed to load apps: ${appProvider.error}',
+                  message: appProvider.errorDetails == null
+                      ? 'Failed to load apps: ${appProvider.error}'
+                      : 'Failed to load apps: ${appProvider.error}\n'
+                            '${appProvider.errorDetails}',
                 )
               else if (appProvider.apps.isEmpty)
                 const EmptyStateWidget(

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -1090,6 +1090,8 @@ class TrueNasApiClient implements ApiClientInterface {
 
     final apps = <App>[];
     Object? firstFailure;
+    StackTrace? firstStackTrace;
+    String? firstFailedName;
     var skipped = 0;
     for (final entry in result) {
       try {
@@ -1101,23 +1103,37 @@ class TrueNasApiClient implements ApiClientInterface {
         apps.add(parse(Map<String, dynamic>.from(entry)));
       } catch (e, stackTrace) {
         skipped++;
-        firstFailure ??= e;
-        final name = entry is Map ? entry['name'] : null;
-        if (kDebugMode) {
-          print('TrueNAS API: $method: skipping app "$name": $e');
+        if (firstFailure == null) {
+          firstFailure = e;
+          firstStackTrace = stackTrace;
+          firstFailedName = entry is Map ? entry['name']?.toString() : null;
         }
-        _telemetry?.getLogger().error(
-          'TrueNAS API: $method returned an app entry that could not be '
-          'parsed; skipping it',
-          error: e,
-          stackTrace: stackTrace,
-          attributes: {
-            'server.id': _server.id,
-            'truenas.method': method,
-            'truenas.app.name': name?.toString() ?? '',
-          },
+      }
+    }
+
+    // One record per response, not per entry: a field that changed shape in
+    // a newer TrueNAS fails every entry the same way, and the catalog is
+    // re-fetched on every refresh.
+    if (skipped > 0) {
+      if (kDebugMode) {
+        print(
+          'TrueNAS API: $method: skipped $skipped of ${result.length} app '
+          'entries, first failure ("$firstFailedName"): $firstFailure',
         );
       }
+      _telemetry?.getLogger().error(
+        'TrueNAS API: $method returned app entries that could not be '
+        'parsed; skipped them',
+        error: firstFailure,
+        stackTrace: firstStackTrace,
+        attributes: {
+          'server.id': _server.id,
+          'truenas.method': method,
+          'truenas.apps.skipped': skipped,
+          'truenas.apps.total': result.length,
+          'truenas.app.name': firstFailedName ?? '',
+        },
+      );
     }
 
     if (apps.isEmpty && skipped > 0) {

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -81,10 +81,11 @@ class TrueNasApiClient implements ApiClientInterface {
   bool _keepaliveEnabled = true;
   Duration _keepaliveInterval = const Duration(seconds: 30);
 
-  /// Requests (other than the keepalive ping itself) still waiting for a
-  /// reply on the current socket, and when the socket became busy.
-  int _inFlightRequests = 0;
-  DateTime? _busySince;
+  /// Start times of the requests (other than the keepalive ping itself)
+  /// still waiting for a reply on the current socket. Each request gets its
+  /// own grace window, so a newer request is not left unprotected because an
+  /// older one has been hanging for longer than [busyGracePeriod].
+  final List<DateTime> _inFlightRequestStarts = [];
 
   /// How long an in-flight request vouches for the socket. While a request is
   /// pending and younger than this, the keepalive does not probe or recover
@@ -321,24 +322,22 @@ class TrueNasApiClient implements ApiClientInterface {
   /// the keepalive's sake (see [busyGracePeriod]). Every application request
   /// goes through here; the keepalive ping itself does not.
   Future<dynamic> _request(String method, [dynamic parameters]) async {
-    if (_inFlightRequests++ == 0) {
-      _busySince = DateTime.now();
-    }
+    final startedAt = DateTime.now();
+    _inFlightRequestStarts.add(startedAt);
     try {
       return await _client!.sendRequest(method, parameters);
     } finally {
-      if (--_inFlightRequests == 0) {
-        _busySince = null;
-      }
+      _inFlightRequestStarts.remove(startedAt);
     }
   }
 
-  /// True while a request younger than [busyGracePeriod] is still waiting
+  /// True while any request younger than [busyGracePeriod] is still waiting
   /// for its reply - evidence the socket is in use, not dead.
   bool get _isBusyWithinGrace {
-    final busySince = _busySince;
-    return busySince != null &&
-        DateTime.now().difference(busySince) < busyGracePeriod;
+    final now = DateTime.now();
+    return _inFlightRequestStarts.any(
+      (startedAt) => now.difference(startedAt) < busyGracePeriod,
+    );
   }
 
   Future<void> _sendKeepalivePing() async {

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -996,9 +996,7 @@ class TrueNasApiClient implements ApiClientInterface {
       return await _traced('truenas.apps.available', () async {
         await _ensureAuthenticated();
         final result = await _client!.sendRequest('app.available');
-        return (result as List<dynamic>)
-            .map((app) => App.fromJson(app as Map<String, dynamic>))
-            .toList();
+        return _parseAppList(result, App.fromJson, method: 'app.available');
       });
     } catch (e) {
       throw _handleError(e);
@@ -1011,13 +1009,75 @@ class TrueNasApiClient implements ApiClientInterface {
       return await _traced('truenas.apps.installed', () async {
         await _ensureAuthenticated();
         final result = await _client!.sendRequest('app.query');
-        return (result as List<dynamic>)
-            .map((app) => _convertTrueNasAppToApp(app as Map<String, dynamic>))
-            .toList();
+        return _parseAppList(
+          result,
+          _convertTrueNasAppToApp,
+          method: 'app.query',
+        );
       });
     } catch (e) {
       throw _handleError(e);
     }
+  }
+
+  /// Parses a list-of-apps response entry by entry, so one app the server
+  /// describes in an unexpected shape doesn't take the whole list down with
+  /// it. TrueNAS has changed individual fields across releases more than
+  /// once (`last_update`, `last_updated`, ...) and every such change used to
+  /// surface as a bare "Connection error" for *all* apps. A skipped entry is
+  /// logged with its name and cause; only when nothing at all could be
+  /// parsed does this throw, since that means the whole response shape is
+  /// off rather than one entry.
+  List<App> _parseAppList(
+    Object? result,
+    App Function(Map<String, dynamic>) parse, {
+    required String method,
+  }) {
+    if (result is! List) {
+      throw FormatException(
+        '$method: expected a list of apps, got ${result.runtimeType}',
+      );
+    }
+
+    final apps = <App>[];
+    Object? firstFailure;
+    var skipped = 0;
+    for (final entry in result) {
+      try {
+        if (entry is! Map) {
+          throw FormatException(
+            'expected an app object, got ${entry.runtimeType}',
+          );
+        }
+        apps.add(parse(Map<String, dynamic>.from(entry)));
+      } catch (e, stackTrace) {
+        skipped++;
+        firstFailure ??= e;
+        final name = entry is Map ? entry['name'] : null;
+        if (kDebugMode) {
+          print('TrueNAS API: $method: skipping app "$name": $e');
+        }
+        _telemetry?.getLogger().error(
+          'TrueNAS API: $method returned an app entry that could not be '
+          'parsed; skipping it',
+          error: e,
+          stackTrace: stackTrace,
+          attributes: {
+            'server.id': _server.id,
+            'truenas.method': method,
+            'truenas.app.name': name?.toString() ?? '',
+          },
+        );
+      }
+    }
+
+    if (apps.isEmpty && skipped > 0) {
+      throw FormatException(
+        '$method: none of the $skipped app entries could be parsed: '
+        '$firstFailure',
+      );
+    }
+    return apps;
   }
 
   /// Convert TrueNAS app query response to our App model
@@ -1641,28 +1701,57 @@ class TrueNasApiClient implements ApiClientInterface {
       );
     }
 
-    // Authentication issues
+    // A JSON-RPC error from the middleware itself. TrueNAS attaches a
+    // `data` map ({error: errno, errname, reason, trace, extra}) to method
+    // call failures, and its message alone ("Method call error") says
+    // nothing - the reason is what the user needs to see.
     if (error is RpcException) {
+      final data = error.data;
+      final reason = data is Map ? data['reason']?.toString() : null;
+      final errname = data is Map ? data['errname']?.toString() : null;
+      final reasonLower = (reason ?? '').toLowerCase();
+      final details = reason == null || reason.isEmpty
+          ? 'JSON-RPC error ${error.code}: ${error.message}'
+          : reason;
+
+      if (errname == 'ENOTAUTHENTICATED' ||
+          reasonLower.contains('not authenticated') ||
+          reasonLower.contains('session is expired')) {
+        return ConnectionException(
+          ConnectionError.authenticationFailed(details: details),
+        );
+      }
+
       if (error.code == 401 ||
           errorString.contains('unauthorized') ||
           errorString.contains('authentication failed') ||
           errorString.contains('invalid credentials')) {
         return ConnectionException(
-          ConnectionError.invalidCredentials(details: error.message),
+          ConnectionError.invalidCredentials(details: details),
         );
       }
 
-      if (error.code == 403 || errorString.contains('forbidden')) {
+      if (error.code == 403 ||
+          errname == 'EACCES' ||
+          errname == 'EPERM' ||
+          errorString.contains('forbidden') ||
+          reasonLower.contains('not authorized')) {
         return ConnectionException(
-          ConnectionError.permissionDenied(details: error.message),
+          ConnectionError.permissionDenied(details: details),
         );
       }
 
-      if (error.code >= 500) {
-        return ConnectionException(
-          ConnectionError.serverError(details: error.message),
-        );
-      }
+      // Anything else the middleware rejected (a method that failed, a
+      // method that doesn't exist on this TrueNAS version, invalid params)
+      // happened on the server, and is not a connectivity problem.
+      return ConnectionException(ConnectionError.serverError(details: details));
+    }
+
+    // The server answered, but not in a shape this client understands.
+    if (error is FormatException || error is TypeError) {
+      return ConnectionException(
+        ConnectionError.invalidResponse(details: error.toString()),
+      );
     }
 
     // WebSocket specific errors
@@ -1682,13 +1771,15 @@ class TrueNasApiClient implements ApiClientInterface {
     );
   }
 
-  Exception _handleError(dynamic error) {
-    // For backward compatibility, convert ConnectionException to regular Exception
+  /// Normalises any failure into a [ConnectionException]. This used to
+  /// re-wrap the classified error as a plain `Exception(message)`, which
+  /// dropped both the [ConnectionErrorType] and the technical details on
+  /// the floor - so every failure reached the UI as a generic "Connection
+  /// error" with nothing to act on.
+  ConnectionException _handleError(dynamic error) {
     if (error is ConnectionException) {
-      return Exception(error.error.message);
+      return error;
     }
-
-    final connectionError = _handleConnectionError(error);
-    return Exception(connectionError.error.message);
+    return _handleConnectionError(error);
   }
 }

--- a/lib/services/truenas_api_client.dart
+++ b/lib/services/truenas_api_client.dart
@@ -80,6 +80,21 @@ class TrueNasApiClient implements ApiClientInterface {
   Timer? _keepaliveTimer;
   bool _keepaliveEnabled = true;
   Duration _keepaliveInterval = const Duration(seconds: 30);
+
+  /// Requests (other than the keepalive ping itself) still waiting for a
+  /// reply on the current socket, and when the socket became busy.
+  int _inFlightRequests = 0;
+  DateTime? _busySince;
+
+  /// How long an in-flight request vouches for the socket. While a request is
+  /// pending and younger than this, the keepalive does not probe or recover
+  /// the connection: a large reply (`app.available` is the whole catalog,
+  /// readmes included - megabytes over a cellular link) keeps the socket
+  /// legitimately busy for longer than the ping timeout, and a pong queues
+  /// behind it. Reconnecting in that state is what used to kill the pending
+  /// request with "The client closed with pending request". After the grace
+  /// period a hung request is no longer taken as a sign of life.
+  Duration busyGracePeriod = const Duration(minutes: 3);
   bool _awaitingPong = false;
 
   TrueNasApiClient(
@@ -302,12 +317,46 @@ class TrueNasApiClient implements ApiClientInterface {
     }
   }
 
+  /// Sends [method] over the current socket, tracking it as in flight for
+  /// the keepalive's sake (see [busyGracePeriod]). Every application request
+  /// goes through here; the keepalive ping itself does not.
+  Future<dynamic> _request(String method, [dynamic parameters]) async {
+    if (_inFlightRequests++ == 0) {
+      _busySince = DateTime.now();
+    }
+    try {
+      return await _client!.sendRequest(method, parameters);
+    } finally {
+      if (--_inFlightRequests == 0) {
+        _busySince = null;
+      }
+    }
+  }
+
+  /// True while a request younger than [busyGracePeriod] is still waiting
+  /// for its reply - evidence the socket is in use, not dead.
+  bool get _isBusyWithinGrace {
+    final busySince = _busySince;
+    return busySince != null &&
+        DateTime.now().difference(busySince) < busyGracePeriod;
+  }
+
   Future<void> _sendKeepalivePing() async {
     // A closed socket is precisely the case that needs recovering. Returning
     // here (as this used to) left the client dead until something else
     // happened to issue a request.
     if (!_hasLiveConnection || !_isAuthenticated) {
       await _handleKeepaliveTimeout();
+      return;
+    }
+
+    // Don't probe a socket that is busy serving a request: the pong would
+    // only queue behind the pending reply, and a timeout here would tear
+    // down the very connection that request is waiting on.
+    if (_isBusyWithinGrace) {
+      if (kDebugMode) {
+        print('TrueNAS API: Skipping keepalive ping, a request is in flight');
+      }
       return;
     }
 
@@ -363,6 +412,12 @@ class TrueNasApiClient implements ApiClientInterface {
     } catch (e) {
       if (kDebugMode) {
         print('TrueNAS API: Keepalive ping failed: $e');
+      }
+      // A request that started after this ping went out can hold the pong
+      // up just the same; it vouches for the socket, so don't reconnect.
+      if (_isBusyWithinGrace) {
+        _awaitingPong = false;
+        return;
       }
       await _handleKeepaliveTimeout();
     }
@@ -751,7 +806,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<UserInfo> getCurrentUser() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('auth.me');
+      final result = await _request('auth.me');
       return UserInfo.fromJson(result as Map<String, dynamic>);
     } catch (e) {
       throw _handleError(e);
@@ -763,7 +818,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getSystemInfo() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.info');
+      final result = await _request('system.info');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -774,7 +829,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getSystemCpuInfo() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.cpu_info');
+      final result = await _request('system.cpu_info');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -785,7 +840,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getSystemMemoryInfo() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.memory_info');
+      final result = await _request('system.memory_info');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -796,7 +851,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<double> getSystemTemperature() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.temperature');
+      final result = await _request('system.temperature');
       return (result as num).toDouble();
     } catch (e) {
       throw _handleError(e);
@@ -808,7 +863,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<List<Map<String, dynamic>>> queryPools() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('pool.query');
+      final result = await _request('pool.query');
       return (result as List<dynamic>).cast<Map<String, dynamic>>();
     } catch (e) {
       throw _handleError(e);
@@ -819,7 +874,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getPoolById(String id) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('pool.query', {'id': id});
+      final result = await _request('pool.query', {'id': id});
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -831,7 +886,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<List<Map<String, dynamic>>> queryDatasets() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('pool.dataset.query');
+      final result = await _request('pool.dataset.query');
       return (result as List<dynamic>).cast<Map<String, dynamic>>();
     } catch (e) {
       throw _handleError(e);
@@ -842,9 +897,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getDatasetById(String id) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('pool.dataset.query', {
-        'id': id,
-      });
+      final result = await _request('pool.dataset.query', {'id': id});
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -856,9 +909,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<List<Map<String, dynamic>>> listDirectory(String path) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('filesystem.listdir', {
-        'path': path,
-      });
+      final result = await _request('filesystem.listdir', {'path': path});
       return (result as List<dynamic>).cast<Map<String, dynamic>>();
     } catch (e) {
       throw _handleError(e);
@@ -869,9 +920,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getFileInfo(String path) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('filesystem.stat', {
-        'path': path,
-      });
+      final result = await _request('filesystem.stat', {'path': path});
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -883,7 +932,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<List<Map<String, dynamic>>> queryDisks() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('disk.query');
+      final result = await _request('disk.query');
       return (result as List<dynamic>).cast<Map<String, dynamic>>();
     } catch (e) {
       throw _handleError(e);
@@ -894,7 +943,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getDiskById(String id) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('disk.query', {'id': id});
+      final result = await _request('disk.query', {'id': id});
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -906,7 +955,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getNetworkInfo() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('network.general.summary');
+      final result = await _request('network.general.summary');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -917,7 +966,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<List<Map<String, dynamic>>> getNetworkInterfaces() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('interface.query');
+      final result = await _request('interface.query');
       return (result as List<dynamic>).cast<Map<String, dynamic>>();
     } catch (e) {
       throw _handleError(e);
@@ -995,7 +1044,7 @@ class TrueNasApiClient implements ApiClientInterface {
     try {
       return await _traced('truenas.apps.available', () async {
         await _ensureAuthenticated();
-        final result = await _client!.sendRequest('app.available');
+        final result = await _request('app.available');
         return _parseAppList(result, App.fromJson, method: 'app.available');
       });
     } catch (e) {
@@ -1008,7 +1057,7 @@ class TrueNasApiClient implements ApiClientInterface {
     try {
       return await _traced('truenas.apps.installed', () async {
         await _ensureAuthenticated();
-        final result = await _client!.sendRequest('app.query');
+        final result = await _request('app.query');
         return _parseAppList(
           result,
           _convertTrueNasAppToApp,
@@ -1194,7 +1243,7 @@ class TrueNasApiClient implements ApiClientInterface {
     try {
       return await _traced('truenas.apps.categories', () async {
         await _ensureAuthenticated();
-        final result = await _client!.sendRequest('app.categories');
+        final result = await _request('app.categories');
         return (result as List<dynamic>).cast<String>();
       });
     } catch (e) {
@@ -1206,7 +1255,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getDockerStatus() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('docker.status');
+      final result = await _request('docker.status');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -1245,7 +1294,7 @@ class TrueNasApiClient implements ApiClientInterface {
     try {
       await _ensureAuthenticated();
       // The TrueNAS API takes just the app name as a string parameter
-      final result = await _client!.sendRequest('app.upgrade', [appName]);
+      final result = await _request('app.upgrade', [appName]);
       // The upgrade method returns the app object on success, so we check if it's not null
       return result != null;
     } catch (e) {
@@ -1260,7 +1309,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<bool> startApp(String appName) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('app.start', [appName]);
+      final result = await _request('app.start', [appName]);
       return result != null;
     } catch (e) {
       if (kDebugMode) {
@@ -1274,7 +1323,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<bool> stopApp(String appName) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('app.stop', [appName]);
+      final result = await _request('app.stop', [appName]);
       return result != null;
     } catch (e) {
       if (kDebugMode) {
@@ -1288,7 +1337,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<bool> restartApp(String appName) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('app.restart', [appName]);
+      final result = await _request('app.restart', [appName]);
       return result != null;
     } catch (e) {
       if (kDebugMode) {
@@ -1329,8 +1378,7 @@ class TrueNasApiClient implements ApiClientInterface {
 
       // Subscribe to realtime reporting data
       _realtimeSubscriptionId =
-          await _client!.sendRequest('core.subscribe', ['reporting.realtime'])
-              as String;
+          await _request('core.subscribe', ['reporting.realtime']) as String;
 
       if (kDebugMode) {
         print(
@@ -1359,9 +1407,7 @@ class TrueNasApiClient implements ApiClientInterface {
 
     try {
       if (_hasLiveConnection) {
-        await _client!.sendRequest('core.unsubscribe', [
-          _realtimeSubscriptionId!,
-        ]);
+        await _request('core.unsubscribe', [_realtimeSubscriptionId!]);
 
         if (kDebugMode) {
           print(
@@ -1413,7 +1459,7 @@ class TrueNasApiClient implements ApiClientInterface {
 
       // Subscribe to app stats data
       _appStatsSubscriptionId =
-          await _client!.sendRequest('core.subscribe', ['app.stats']) as String;
+          await _request('core.subscribe', ['app.stats']) as String;
 
       if (kDebugMode) {
         print(
@@ -1442,9 +1488,7 @@ class TrueNasApiClient implements ApiClientInterface {
 
     try {
       if (_hasLiveConnection) {
-        await _client!.sendRequest('core.unsubscribe', [
-          _appStatsSubscriptionId!,
-        ]);
+        await _request('core.unsubscribe', [_appStatsSubscriptionId!]);
 
         if (kDebugMode) {
           print(
@@ -1474,7 +1518,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getSystemGeneralConfig() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.general.config');
+      final result = await _request('system.general.config');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -1485,7 +1529,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<Map<String, dynamic>> getSystemAdvancedConfig() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.advanced.config');
+      final result = await _request('system.advanced.config');
       return result as Map<String, dynamic>;
     } catch (e) {
       throw _handleError(e);
@@ -1496,7 +1540,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<String> getSystemProductType() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('system.product_type');
+      final result = await _request('system.product_type');
       return result as String;
     } catch (e) {
       throw _handleError(e);
@@ -1507,7 +1551,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<bool> isIxHardware() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('truenas.is_ix_hardware');
+      final result = await _request('truenas.is_ix_hardware');
       return result as bool;
     } catch (e) {
       throw _handleError(e);
@@ -1519,7 +1563,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<List<Job>> getJobs() async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest('core.get_jobs');
+      final result = await _request('core.get_jobs');
       final jobs = (result as List<dynamic>).cast<Map<String, dynamic>>().map(
         Job.fromJson,
       );
@@ -1558,8 +1602,7 @@ class TrueNasApiClient implements ApiClientInterface {
       _jobsController ??= StreamController<List<Job>>.broadcast();
 
       _jobsSubscriptionId =
-          await _client!.sendRequest('core.subscribe', ['core.get_jobs'])
-              as String;
+          await _request('core.subscribe', ['core.get_jobs']) as String;
 
       _isSubscribedToJobs = true;
 
@@ -1582,7 +1625,7 @@ class TrueNasApiClient implements ApiClientInterface {
 
     try {
       if (_hasLiveConnection) {
-        await _client!.sendRequest('core.unsubscribe', [_jobsSubscriptionId!]);
+        await _request('core.unsubscribe', [_jobsSubscriptionId!]);
 
         if (kDebugMode) {
           print(
@@ -1612,7 +1655,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<void> abortJob(int jobId) async {
     try {
       await _ensureAuthenticated();
-      await _client!.sendRequest('core.job_abort', [jobId]);
+      await _request('core.job_abort', [jobId]);
     } catch (e) {
       throw _handleError(e);
     }
@@ -1622,7 +1665,7 @@ class TrueNasApiClient implements ApiClientInterface {
   Future<int> rerunJob(Job job) async {
     try {
       await _ensureAuthenticated();
-      final result = await _client!.sendRequest(job.method, job.arguments);
+      final result = await _request(job.method, job.arguments);
       return result as int;
     } catch (e) {
       throw _handleError(e);

--- a/lib/widgets/connection_error_widget.dart
+++ b/lib/widgets/connection_error_widget.dart
@@ -98,6 +98,8 @@ class ConnectionErrorWidget extends StatelessWidget {
         return CupertinoIcons.exclamationmark_shield;
       case ConnectionErrorType.serverError:
         return CupertinoIcons.exclamationmark_triangle;
+      case ConnectionErrorType.invalidResponse:
+        return CupertinoIcons.exclamationmark_bubble;
       case ConnectionErrorType.unknown:
         return CupertinoIcons.question_circle;
     }

--- a/test/providers/app_provider_test.dart
+++ b/test/providers/app_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:truehub/models/app.dart';
 import 'package:truehub/models/app_config.dart';
@@ -50,6 +52,24 @@ class _ClassifiedFailureClient extends FakeApiClient {
   Future<List<App>> getInstalledApps() async {
     calls.add('getInstalledApps');
     throw ConnectionException(failure);
+  }
+}
+
+/// A [FakeApiClient] whose catalog call blocks on [gate] while installed
+/// apps resolve immediately.
+class _GatedCatalogClient extends FakeApiClient {
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<List<App>> getAvailableApps() async {
+    await gate.future;
+    return super.getAvailableApps();
+  }
+}
+
+Future<void> _waitUntil(bool Function() condition) async {
+  while (!condition()) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
   }
 }
 
@@ -325,6 +345,60 @@ void main() {
         expect(appProvider.catalogError, isNotNull);
         expect(appProvider.availableApps, hasLength(1));
         expect(appProvider.installedApps, hasLength(1));
+      },
+    );
+
+    test('installed apps are exposed as soon as they arrive, before the '
+        'catalog has finished loading', () async {
+      final client = _GatedCatalogClient()
+        ..installedApps = [_sampleApp(name: 'plex', installed: true)]
+        ..availableApps = [
+          _sampleApp(name: 'sonarr', installed: false, portals: const {}),
+        ]
+        ..appCategories = ['media'];
+      TestProviders.mockApiClientManager.addMockClient(testServer.id, client);
+      await appProvider.setServer(testServer);
+
+      final load = appProvider.loadApps();
+      await _waitUntil(() => !appProvider.isLoading);
+
+      expect(appProvider.installedApps, hasLength(1));
+      expect(appProvider.availableApps, isEmpty);
+      expect(appProvider.isCatalogLoading, isTrue);
+      expect(appProvider.connectionError, isNull);
+
+      client.gate.complete();
+      await load;
+
+      expect(appProvider.isCatalogLoading, isFalse);
+      expect(appProvider.availableApps, hasLength(1));
+      expect(appProvider.installedApps, hasLength(1));
+      expect(appProvider.categories, ['media']);
+      expect(appProvider.catalogError, isNull);
+    });
+
+    test(
+      'a catalog that arrives after the server was switched is dropped',
+      () async {
+        final client = _GatedCatalogClient()
+          ..installedApps = [_sampleApp(name: 'plex', installed: true)]
+          ..availableApps = [
+            _sampleApp(name: 'sonarr', installed: false, portals: const {}),
+          ];
+        TestProviders.mockApiClientManager.addMockClient(testServer.id, client);
+        await appProvider.setServer(testServer);
+
+        final load = appProvider.loadApps();
+        await _waitUntil(() => !appProvider.isLoading);
+        expect(appProvider.isCatalogLoading, isTrue);
+
+        await appProvider.setServer(null);
+        client.gate.complete();
+        await load;
+
+        expect(appProvider.appConfigs, isEmpty);
+        expect(appProvider.isCatalogLoading, isFalse);
+        expect(appProvider.catalogError, isNull);
       },
     );
 

--- a/test/providers/app_provider_test.dart
+++ b/test/providers/app_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:truehub/models/app.dart';
 import 'package:truehub/models/app_config.dart';
+import 'package:truehub/models/connection_error.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/providers/app_provider.dart';
 import 'package:truehub/services/database.dart';
@@ -35,6 +36,21 @@ App _sampleApp({
     usedPorts: const [],
     portals: portals,
   );
+}
+
+/// A [FakeApiClient] whose installed-apps call fails the way the real
+/// client fails: with a classified [ConnectionException], not a bare
+/// [Exception].
+class _ClassifiedFailureClient extends FakeApiClient {
+  ConnectionError failure = ConnectionError.permissionDenied(
+    details: 'Not authorized',
+  );
+
+  @override
+  Future<List<App>> getInstalledApps() async {
+    calls.add('getInstalledApps');
+    throw ConnectionException(failure);
+  }
 }
 
 void main() {
@@ -216,20 +232,128 @@ void main() {
       expect(fakeClient.calls, contains('subscribeToAppStats'));
     });
 
+    test('an installed-apps failure falls back to persisted (empty) data with '
+        'an error that keeps the cause', () async {
+      await appProvider.setServer(testServer);
+      fakeClient.failingMethods.add('getInstalledApps');
+
+      await appProvider.loadApps();
+
+      expect(appProvider.connectionError, isNotNull);
+      expect(appProvider.error, appProvider.connectionError!.shortMessage);
+      expect(
+        appProvider.errorDetails,
+        contains('getInstalledApps configured to fail'),
+      );
+      expect(appProvider.catalogError, isNull);
+      expect(appProvider.appConfigs, isEmpty);
+      expect(appProvider.isLoading, isFalse);
+    });
+
     test(
-      'a failure falls back to persisted (empty) data with an error',
+      'a classified failure from the client is surfaced as-is, type and '
+      'details included, instead of being flattened to "Connection error"',
       () async {
+        final client = _ClassifiedFailureClient();
+        TestProviders.mockApiClientManager.addMockClient(testServer.id, client);
         await appProvider.setServer(testServer);
-        fakeClient.failingMethods.add('getAvailableApps');
 
         await appProvider.loadApps();
 
-        expect(appProvider.connectionError, isNotNull);
-        expect(appProvider.error, appProvider.connectionError!.shortMessage);
-        expect(appProvider.appConfigs, isEmpty);
-        expect(appProvider.isLoading, isFalse);
+        expect(
+          appProvider.connectionError?.type,
+          ConnectionErrorType.permissionDenied,
+        );
+        expect(appProvider.error, 'Permission denied');
+        expect(appProvider.errorDetails, 'Not authorized');
       },
     );
+
+    test('a catalog failure degrades to installed apps instead of failing the '
+        'whole load', () async {
+      await appProvider.setServer(testServer);
+      fakeClient.failingMethods.add('getAvailableApps');
+      fakeClient.installedApps = [_sampleApp(name: 'plex', installed: true)];
+      fakeClient.appCategories = ['media'];
+
+      await appProvider.loadApps();
+
+      expect(appProvider.connectionError, isNull);
+      expect(appProvider.error, isNull);
+      expect(appProvider.installedApps, hasLength(1));
+      expect(appProvider.categories, ['media']);
+      expect(appProvider.catalogError, isNotNull);
+      expect(
+        appProvider.catalogError!.technicalDetails,
+        contains('getAvailableApps configured to fail'),
+      );
+      expect(appProvider.isLoading, isFalse);
+    });
+
+    test('a categories failure is a catalog failure too', () async {
+      await appProvider.setServer(testServer);
+      fakeClient.failingMethods.add('getAppCategories');
+      fakeClient.installedApps = [_sampleApp(name: 'plex', installed: true)];
+      fakeClient.availableApps = [
+        _sampleApp(name: 'sonarr', installed: false, portals: const {}),
+      ];
+
+      await appProvider.loadApps();
+
+      expect(appProvider.connectionError, isNull);
+      expect(appProvider.catalogError, isNotNull);
+      expect(appProvider.installedApps, hasLength(1));
+      // The available list itself still came through.
+      expect(appProvider.availableApps, hasLength(1));
+      expect(appProvider.categories, isEmpty);
+    });
+
+    test(
+      'a catalog failure keeps the previously synced catalog entries',
+      () async {
+        await appProvider.setServer(testServer);
+        fakeClient.installedApps = [_sampleApp(name: 'plex', installed: true)];
+        fakeClient.availableApps = [
+          _sampleApp(name: 'sonarr', installed: false, portals: const {}),
+        ];
+        await appProvider.loadApps();
+        expect(appProvider.availableApps, hasLength(1));
+
+        fakeClient.failingMethods.add('getAvailableApps');
+        await appProvider.loadApps();
+
+        expect(appProvider.catalogError, isNotNull);
+        expect(appProvider.availableApps, hasLength(1));
+        expect(appProvider.installedApps, hasLength(1));
+      },
+    );
+
+    test('a successful reload clears a previous catalog error', () async {
+      await appProvider.setServer(testServer);
+      fakeClient.failingMethods.add('getAvailableApps');
+      await appProvider.loadApps();
+      expect(appProvider.catalogError, isNotNull);
+
+      fakeClient.failingMethods.remove('getAvailableApps');
+      await appProvider.loadApps();
+
+      expect(appProvider.catalogError, isNull);
+    });
+
+    test('an installed-apps failure wins over a simultaneous catalog failure '
+        'and leaves no unhandled error behind', () async {
+      await appProvider.setServer(testServer);
+      fakeClient.failingMethods
+        ..add('getInstalledApps')
+        ..add('getAvailableApps')
+        ..add('getAppCategories');
+
+      await appProvider.loadApps();
+
+      expect(appProvider.connectionError, isNotNull);
+      expect(appProvider.catalogError, isNull);
+      expect(appProvider.isLoading, isFalse);
+    });
 
     test('is a no-op without a current server', () async {
       await appProvider.loadApps();

--- a/test/screens/server_apps_screen_test.dart
+++ b/test/screens/server_apps_screen_test.dart
@@ -523,7 +523,7 @@ void main() {
     testWidgets('shows an error view with Retry when loading fails', (
       WidgetTester tester,
     ) async {
-      fakeClient.failingMethods.add('getAvailableApps');
+      fakeClient.failingMethods.add('getInstalledApps');
 
       await tester.pumpWidget(createTestApp());
       await pumpUntilAsync(
@@ -533,6 +533,11 @@ void main() {
       await tester.pump();
 
       expect(find.text('Failed to load apps'), findsOneWidget);
+      // The cause is shown, not just a generic short message.
+      expect(
+        find.textContaining('getInstalledApps configured to fail'),
+        findsOneWidget,
+      );
       expect(find.text('Retry'), findsOneWidget);
       expect(find.byType(AppCardWidget), findsNothing);
       expectNoLayoutOverflow(tester);
@@ -541,7 +546,7 @@ void main() {
     testWidgets('Retry re-attempts the load and can succeed', (
       WidgetTester tester,
     ) async {
-      fakeClient.failingMethods.add('getAvailableApps');
+      fakeClient.failingMethods.add('getInstalledApps');
 
       await tester.pumpWidget(createTestApp());
       await pumpUntilAsync(
@@ -551,7 +556,7 @@ void main() {
       await tester.pump();
       expect(find.text('Failed to load apps'), findsOneWidget);
 
-      fakeClient.failingMethods.remove('getAvailableApps');
+      fakeClient.failingMethods.remove('getInstalledApps');
       fakeClient.installedApps = [
         _app(name: 'plex', title: 'Plex', installed: true),
       ];
@@ -566,6 +571,86 @@ void main() {
       expect(find.text('Failed to load apps'), findsNothing);
       expect(find.byType(AppCardWidget), findsOneWidget);
     });
+  });
+
+  group('ServerAppsScreen - catalog failure', () {
+    testWidgets(
+      'installed apps stay usable when only the catalog fails to load',
+      (WidgetTester tester) async {
+        fakeClient.failingMethods.add('getAvailableApps');
+        fakeClient.installedApps = [
+          _app(name: 'plex', title: 'Plex', installed: true),
+        ];
+        fakeClient.appCategories = [];
+
+        await tester.pumpWidget(createTestApp());
+        await settleInitialLoad(tester);
+        await tester.pump();
+
+        expect(find.text('Failed to load apps'), findsNothing);
+        expect(find.byType(AppCardWidget), findsOneWidget);
+        expect(find.text('plex'), findsOneWidget);
+        expectNoLayoutOverflow(tester);
+      },
+    );
+
+    testWidgets('the Available tab reports the catalog failure with Retry', (
+      WidgetTester tester,
+    ) async {
+      fakeClient.failingMethods.add('getAvailableApps');
+      fakeClient.installedApps = [
+        _app(name: 'plex', title: 'Plex', installed: true),
+      ];
+      fakeClient.appCategories = [];
+
+      await tester.pumpWidget(createTestApp());
+      await settleInitialLoad(tester);
+      await tester.pump();
+
+      await tester.tap(find.text('Available'));
+      await tester.pump();
+
+      expect(find.text('Failed to load app catalog'), findsOneWidget);
+      expect(
+        find.textContaining('getAvailableApps configured to fail'),
+        findsOneWidget,
+      );
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.byType(AppCardWidget), findsNothing);
+      expectNoLayoutOverflow(tester);
+    });
+
+    testWidgets(
+      'a previously synced catalog stays listed with a stale notice',
+      (WidgetTester tester) async {
+        fakeClient.installedApps = [
+          _app(name: 'plex', title: 'Plex', installed: true),
+        ];
+        fakeClient.availableApps = [
+          _app(name: 'radarr', title: 'Radarr', installed: false),
+        ];
+        fakeClient.appCategories = [];
+
+        await tester.pumpWidget(createTestApp());
+        await settleInitialLoad(tester);
+        await tester.pump();
+
+        fakeClient.failingMethods.add('getAvailableApps');
+        await appProvider.refreshApps();
+        await tester.pump();
+
+        await tester.tap(find.text('Available'));
+        await tester.pump();
+
+        expect(find.text('Radarr'), findsOneWidget);
+        expect(
+          find.textContaining('Catalog could not be refreshed'),
+          findsOneWidget,
+        );
+        expect(find.text('Failed to load app catalog'), findsNothing);
+        expectNoLayoutOverflow(tester);
+      },
+    );
   });
 
   group('ServerAppsScreen - layout', () {

--- a/test/screens/server_apps_screen_test.dart
+++ b/test/screens/server_apps_screen_test.dart
@@ -19,11 +19,24 @@ import '../helpers/test_database.dart';
 import '../helpers/test_providers.dart';
 import '../helpers/test_surfaces.dart';
 
-/// A [FakeApiClient] whose [getAvailableApps] blocks on [gate] until the
+/// A [FakeApiClient] whose [getInstalledApps] blocks on [gate] until the
 /// test completes it - used to deterministically observe
 /// [ServerAppsScreen]'s loading spinner instead of racing a fake client that
 /// resolves within a single microtask.
 class _GatedFakeApiClient extends FakeApiClient {
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<List<App>> getInstalledApps() async {
+    await gate.future;
+    return super.getInstalledApps();
+  }
+}
+
+/// A [FakeApiClient] whose catalog call ([getAvailableApps]) blocks on
+/// [gate] while installed apps resolve immediately - the slow-catalog case
+/// the screen must stay usable through.
+class _GatedCatalogFakeApiClient extends FakeApiClient {
   final Completer<void> gate = Completer<void>();
 
   @override
@@ -517,6 +530,47 @@ void main() {
       expect(find.byType(AppCardWidget), findsOneWidget);
       expect(find.text('plex'), findsOneWidget);
     });
+
+    testWidgets(
+      'installed apps are shown while the catalog is still loading, and the '
+      'Available tab shows its own spinner until the catalog arrives',
+      (WidgetTester tester) async {
+        final gatedClient = _GatedCatalogFakeApiClient();
+        gatedClient.installedApps = [
+          _app(name: 'plex', title: 'Plex', installed: true),
+        ];
+        gatedClient.availableApps = [
+          _app(name: 'radarr', title: 'Radarr', installed: false),
+        ];
+        gatedClient.appCategories = [];
+        TestProviders.mockApiClientManager.addMockClient(
+          testServer.id,
+          gatedClient,
+        );
+        addTearDown(gatedClient.dispose);
+
+        await tester.pumpWidget(createTestApp());
+        await settleInitialLoad(tester);
+        await tester.pump();
+
+        // Installed apps are already usable while the catalog is pending.
+        expect(appProvider.isCatalogLoading, isTrue);
+        expect(find.byType(AppCardWidget), findsOneWidget);
+        expect(find.text('plex'), findsOneWidget);
+
+        await tester.tap(find.text('Available'));
+        await tester.pump();
+        expect(find.text('Loading app catalog...'), findsOneWidget);
+        expect(find.byType(AppCardWidget), findsNothing);
+
+        gatedClient.gate.complete();
+        await pumpUntilAsync(tester, () => !appProvider.isCatalogLoading);
+        await tester.pump();
+
+        expect(find.text('Loading app catalog...'), findsNothing);
+        expect(find.text('Radarr'), findsOneWidget);
+      },
+    );
   });
 
   group('ServerAppsScreen - error state', () {
@@ -636,8 +690,7 @@ void main() {
         await tester.pump();
 
         fakeClient.failingMethods.add('getAvailableApps');
-        await appProvider.refreshApps();
-        await tester.pump();
+        await runRealAsync(tester, appProvider.refreshApps);
 
         await tester.tap(find.text('Available'));
         await tester.pump();
@@ -649,6 +702,35 @@ void main() {
         );
         expect(find.text('Failed to load app catalog'), findsNothing);
         expectNoLayoutOverflow(tester);
+      },
+    );
+
+    testWidgets(
+      'a search that matches nothing in a stale catalog is an empty search '
+      'result, not a catalog error',
+      (WidgetTester tester) async {
+        fakeClient.installedApps = [
+          _app(name: 'plex', title: 'Plex', installed: true),
+        ];
+        fakeClient.availableApps = [
+          _app(name: 'radarr', title: 'Radarr', installed: false),
+        ];
+        fakeClient.appCategories = [];
+
+        await tester.pumpWidget(createTestApp());
+        await settleInitialLoad(tester);
+        await tester.pump();
+
+        fakeClient.failingMethods.add('getAvailableApps');
+        await runRealAsync(tester, appProvider.refreshApps);
+
+        await tester.tap(find.text('Available'));
+        await tester.pump();
+        await tester.enterText(find.byType(CupertinoSearchTextField), 'zzz');
+        await tester.pump();
+
+        expect(find.text('No apps match your search'), findsOneWidget);
+        expect(find.text('Failed to load app catalog'), findsNothing);
       },
     );
   });

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter_otel/flutter_otel.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
+import 'package:truehub/models/app.dart';
 import 'package:truehub/models/connection_error.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/services/truenas_api_client.dart';
@@ -773,6 +776,84 @@ void main() {
         ),
       );
     });
+
+    test('keepalive does not probe or reconnect while a request is still '
+        'waiting for its reply', () async {
+      // The failure seen in the field: app.available is megabytes of
+      // catalog, and over a slow link it takes longer than the 10s ping
+      // timeout to arrive. The pong queues behind it, the keepalive
+      // declared the socket dead and reconnected, and the pending request
+      // died with "The client closed with pending request".
+      final release = Completer<void>();
+      var pingCount = 0;
+      server
+        ..onMethod('core.ping', (_) {
+          pingCount++;
+          return 'pong';
+        })
+        ..onMethod('app.categories', (_) => <String>[])
+        ..onMethod('app.available', (_) async {
+          await release.future;
+          return [
+            {'name': 'plex', 'title': 'Plex'},
+          ];
+        });
+      client.setKeepaliveInterval(const Duration(milliseconds: 20));
+
+      // Connect and authenticate first (keepalive starts on login), so the
+      // request below is the only thing that can hold the socket busy.
+      await client.getAppCategories();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final pingsBefore = pingCount;
+
+      final pending = client.getAvailableApps();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(
+        pingCount,
+        pingsBefore,
+        reason: 'the socket is demonstrably in use; no probe is needed',
+      );
+      expect(server.connectionCount, 1);
+
+      release.complete();
+      final apps = await pending;
+      expect(apps.single.name, 'plex');
+
+      // Once the socket is idle again, keepalive resumes.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(pingCount, greaterThan(pingsBefore));
+      expect(server.connectionCount, 1);
+    });
+
+    test(
+      'a request hung past the grace period no longer holds keepalive off',
+      () async {
+        final never = Completer<void>();
+        var pingCount = 0;
+        server
+          ..onMethod('core.ping', (_) {
+            pingCount++;
+            return 'pong';
+          })
+          ..onMethod('app.available', (_) async {
+            await never.future;
+            return <Object>[];
+          });
+        client
+          ..busyGracePeriod = const Duration(milliseconds: 50)
+          ..setKeepaliveInterval(const Duration(milliseconds: 20));
+
+        unawaited(client.getAvailableApps().catchError((_) => <App>[]));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(
+          pingCount,
+          greaterThan(0),
+          reason: 'after the grace period the socket must be probed again',
+        );
+      },
+    );
 
     test('concurrent first calls share one connection and one login', () async {
       // AppProvider._loadAppsOnline issues these three calls in a single

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_otel/flutter_otel.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as json_rpc;
+import 'package:truehub/models/connection_error.dart';
 import 'package:truehub/models/nas_server.dart';
 import 'package:truehub/services/truenas_api_client.dart';
 
@@ -555,6 +556,224 @@ void main() {
       expect(minimal.train, 'community');
     });
 
+    test(
+      'getAvailableApps skips an app entry it cannot parse and keeps the rest',
+      () async {
+        server.onMethod(
+          'app.available',
+          (_) => [
+            {'name': 'plex', 'title': 'Plex'},
+            // A malformed entry, of the "one field changed shape in a newer
+            // TrueNAS" kind: maintainers should be a list of objects.
+            {
+              'name': 'broken',
+              'maintainers': ['not-a-map'],
+            },
+            'not-even-an-object',
+            {'name': 'sonarr', 'title': 'Sonarr'},
+          ],
+        );
+
+        final apps = await client.getAvailableApps();
+
+        expect(apps.map((a) => a.name), ['plex', 'sonarr']);
+      },
+    );
+
+    test(
+      'getInstalledApps skips an app entry it cannot parse and keeps the rest',
+      () async {
+        server.onMethod(
+          'app.query',
+          (_) => [
+            {'name': 'plex', 'state': 'RUNNING'},
+            {
+              'name': 'broken',
+              'state': 'RUNNING',
+              'active_workloads': {
+                'used_ports': ['not-a-map'],
+              },
+            },
+          ],
+        );
+
+        final apps = await client.getInstalledApps();
+
+        expect(apps.map((a) => a.name), ['plex']);
+      },
+    );
+
+    test('a list where nothing parses is an invalidResponse error, with the '
+        'cause in the details', () async {
+      server.onMethod(
+        'app.available',
+        (_) => [
+          {
+            'name': 'broken',
+            'maintainers': ['not-a-map'],
+          },
+        ],
+      );
+
+      await expectLater(
+        client.getAvailableApps(),
+        throwsA(
+          isA<ConnectionException>()
+              .having(
+                (e) => e.error.type,
+                'type',
+                ConnectionErrorType.invalidResponse,
+              )
+              .having(
+                (e) => e.error.technicalDetails,
+                'details',
+                contains('app.available'),
+              ),
+        ),
+      );
+    });
+
+    test('a non-list app response is an invalidResponse error', () async {
+      server.onMethod('app.available', (_) => {'unexpected': 'shape'});
+
+      await expectLater(
+        client.getAvailableApps(),
+        throwsA(
+          isA<ConnectionException>().having(
+            (e) => e.error.type,
+            'type',
+            ConnectionErrorType.invalidResponse,
+          ),
+        ),
+      );
+    });
+
+    test('a "Not authorized" middleware error is a permissionDenied error '
+        'carrying the reason', () async {
+      // The shape TrueNAS's JSON-RPC handler emits for a CallError raised
+      // by authorize_method_call: CallError('Not authorized', EACCES).
+      server.onMethod(
+        'app.available',
+        (_) => throw json_rpc.RpcException(
+          -32001,
+          'Method call error',
+          data: {
+            'error': 13,
+            'errname': 'EACCES',
+            'reason': 'Not authorized',
+            'trace': null,
+            'extra': null,
+          },
+        ),
+      );
+
+      await expectLater(
+        client.getAvailableApps(),
+        throwsA(
+          isA<ConnectionException>()
+              .having(
+                (e) => e.error.type,
+                'type',
+                ConnectionErrorType.permissionDenied,
+              )
+              .having(
+                (e) => e.error.technicalDetails,
+                'details',
+                'Not authorized',
+              ),
+        ),
+      );
+    });
+
+    test(
+      'an expired-session middleware error is an authenticationFailed error',
+      () async {
+        server.onMethod(
+          'app.query',
+          (_) => throw json_rpc.RpcException(
+            -32001,
+            'Method call error',
+            data: {
+              'error': 13,
+              'errname': 'EACCES',
+              'reason': 'Session is expired',
+            },
+          ),
+        );
+
+        await expectLater(
+          client.getInstalledApps(),
+          throwsA(
+            isA<ConnectionException>().having(
+              (e) => e.error.type,
+              'type',
+              ConnectionErrorType.authenticationFailed,
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'any other middleware call error is a serverError carrying the reason',
+      () async {
+        server.onMethod(
+          'app.available',
+          (_) => throw json_rpc.RpcException(
+            -32001,
+            'Method call error',
+            data: {
+              'error': 14,
+              'errname': 'EFAULT',
+              'reason': 'Catalog is not synced yet',
+            },
+          ),
+        );
+
+        await expectLater(
+          client.getAvailableApps(),
+          throwsA(
+            isA<ConnectionException>()
+                .having(
+                  (e) => e.error.type,
+                  'type',
+                  ConnectionErrorType.serverError,
+                )
+                .having(
+                  (e) => e.error.technicalDetails,
+                  'details',
+                  'Catalog is not synced yet',
+                ),
+          ),
+        );
+      },
+    );
+
+    test('a middleware error without a reason keeps the JSON-RPC code and '
+        'message as details', () async {
+      server.onMethod(
+        'app.categories',
+        (_) => throw json_rpc.RpcException(-32601, 'Method does not exist'),
+      );
+
+      await expectLater(
+        client.getAppCategories(),
+        throwsA(
+          isA<ConnectionException>()
+              .having(
+                (e) => e.error.type,
+                'type',
+                ConnectionErrorType.serverError,
+              )
+              .having(
+                (e) => e.error.technicalDetails,
+                'details',
+                'JSON-RPC error -32601: Method does not exist',
+              ),
+        ),
+      );
+    });
+
     test('concurrent first calls share one connection and one login', () async {
       // AppProvider._loadAppsOnline issues these three calls in a single
       // Future.wait against a client that has never connected. Each call
@@ -892,7 +1111,16 @@ void main() {
         final client = TrueNasApiClient(testServer, null, telemetry);
         addTearDown(client.close);
 
-        await expectLater(client.getAvailableApps(), throwsException);
+        await expectLater(
+          client.getAvailableApps(),
+          throwsA(
+            isA<ConnectionException>().having(
+              (e) => e.error.type,
+              'type',
+              ConnectionErrorType.invalidResponse,
+            ),
+          ),
+        );
 
         final span = telemetry.spans.singleWhere(
           (s) => s.name == 'truenas.apps.available',

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -855,6 +855,47 @@ void main() {
       },
     );
 
+    test('a newer request keeps its own grace window even while an older one '
+        'has been hung for longer than the grace period', () async {
+      final never = Completer<void>();
+      final release = Completer<void>();
+      var pingCount = 0;
+      server
+        ..onMethod('core.ping', (_) {
+          pingCount++;
+          return 'pong';
+        })
+        ..onMethod('app.available', (_) async {
+          await never.future;
+          return <Object>[];
+        })
+        ..onMethod('app.categories', (_) async {
+          await release.future;
+          return <String>[];
+        });
+      client
+        ..busyGracePeriod = const Duration(milliseconds: 150)
+        ..setKeepaliveInterval(const Duration(milliseconds: 20));
+
+      // The old request outlives its grace period; keepalive resumes.
+      unawaited(client.getAvailableApps().catchError((_) => <App>[]));
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(pingCount, greaterThan(0));
+
+      // A newer request must hold keepalive off again for its own grace.
+      final pingsBefore = pingCount;
+      final pending = client.getAppCategories();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(
+        pingCount,
+        pingsBefore,
+        reason: 'the newer request is younger than the grace period',
+      );
+
+      release.complete();
+      await pending;
+    });
+
     test('concurrent first calls share one connection and one login', () async {
       // AppProvider._loadAppsOnline issues these three calls in a single
       // Future.wait against a client that has never connected. Each call


### PR DESCRIPTION
## Summary

This PR significantly improves error handling in the app loading pipeline by:
1. Making the TrueNAS API client resilient to malformed app entries in list responses
2. Distinguishing between critical failures (installed apps) and degraded failures (catalog)
3. Surfacing detailed error information instead of generic "Connection error" messages
4. Adding a new `invalidResponse` error type for response-shape mismatches

## Key Changes

**API Client Resilience (`truenas_api_client.dart`)**
- Added `_parseAppList()` method that parses app list responses entry-by-entry, skipping malformed entries while logging them
- Only throws when the entire list fails to parse (indicating a fundamental response-shape problem)
- Enhanced `_handleError()` to preserve `ConnectionException` with full error type and technical details instead of flattening to generic `Exception`
- Improved middleware error handling to extract and surface the `reason` field from TrueNAS error responses
- Added detection for expired sessions (`ENOTAUTHENTICATED`, "session is expired") as `authenticationFailed` errors
- Added detection for permission errors (`EACCES`, `EPERM`, "not authorized") as `permissionDenied` errors
- Added new `invalidResponse` error type for `FormatException` and `TypeError` responses

**App Provider Resilience (`app_provider.dart`)**
- Separated installed apps loading from catalog loading with different failure semantics
- Installed apps (`app.query`) failure = critical, fails the entire load
- Catalog (`app.available` + `app.categories`) failures = degraded, allows installed apps to remain usable
- Added `_settle()` helper to capture async outcomes without throwing, preventing unhandled errors
- Added `catalogError` property to track catalog-specific failures separately from connection errors
- Catalog failures preserve previously synced entries, showing them with a stale notice

**UI Updates (`server_apps_screen.dart`)**
- Shows detailed error information (technical details) alongside short error messages
- Displays "Failed to load app catalog" error only on the Available tab when catalog fails
- Shows a notice above stale catalog entries when refresh fails
- Installed apps remain fully functional when only the catalog fails

**Error Model (`connection_error.dart`)**
- Added `ConnectionErrorType.invalidResponse` for response-shape mismatches
- Provides specific troubleshooting guidance for invalid responses

**Test Coverage**
- Added comprehensive tests for malformed app entry handling
- Added tests for catalog failure degradation vs. critical failure
- Added tests for error type classification (permission denied, authentication failed, server errors)
- Updated existing tests to verify error details are preserved and displayed

## Implementation Details

The key insight is that TrueNAS app responses can change shape between versions (field renames, type changes), and a single malformed entry shouldn't hide all apps. The `_parseAppList()` method handles this by:
- Attempting to parse each entry independently
- Logging skipped entries with their name and cause
- Only throwing if nothing could be parsed (indicating a real problem)

The app provider now uses a "settled futures" pattern to load catalog data without letting its failure propagate to the installed apps load, enabling graceful degradation where users can still see and manage their installed apps even if the catalog is temporarily unavailable.

https://claude.ai/code/session_01UcA62JTp1vRksgX7bqW2QQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer connection error messages, including details for unreadable server responses and permission issues.
  * Added retryable handling for invalid server responses.
  * Added a loading state for available apps and categories.

* **Bug Fixes**
  * Installed apps remain available while catalog data loads or fails.
  * Previously loaded catalog entries remain visible when refreshes fail.
  * Malformed app entries no longer prevent valid apps from loading.
  * Improved error classification and display for authentication, authorization, and server failures.
  * Catalog errors no longer replace normal empty-search results when searching stale data.
  * Improved request reliability during reconnects and keepalive checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->