### PR TITLE
chore: enable oss@cedricziel plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
     }
   },
   "enabledPlugins": {
-    "common@cedricziel": true
+    "common@cedricziel": true,
+    "oss@cedricziel": true
   }
 }


### PR DESCRIPTION
## Summary
- Enables the `oss@cedricziel` plugin from https://github.com/cedricziel/claude-plugins/tree/main/plugins/oss in `.claude/settings.json`
- Currently an empty scaffold for open-source project conventions (depends on `common`, no skills/hooks yet), so this has no behavioral effect today but wires it up for future use

## Test plan
- [x] Verified `plugin.json` for the `oss` plugin to confirm it's safe to enable (no hooks/skills active yet)
- [ ] N/A — config-only change, no code paths affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project configuration to enable an additional development plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->