### PR TITLE
test: stabilize keepalive grace-window test against in-flight pings

### DIFF
--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -785,6 +785,7 @@ void main() {
       // declared the socket dead and reconnected, and the pending request
       // died with "The client closed with pending request".
       final release = Completer<void>();
+      final availableReceived = Completer<void>();
       var pingCount = 0;
       server
         ..onMethod('core.ping', (_) {
@@ -793,6 +794,7 @@ void main() {
         })
         ..onMethod('app.categories', (_) => <String>[])
         ..onMethod('app.available', (_) async {
+          availableReceived.complete();
           await release.future;
           return [
             {'name': 'plex', 'title': 'Plex'},
@@ -804,9 +806,12 @@ void main() {
       // request below is the only thing that can hold the socket busy.
       await client.getAppCategories();
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      final pingsBefore = pingCount;
 
+      // Frames on one socket arrive in order, so once the server has seen
+      // this request, any ping sent before it has already been counted.
       final pending = client.getAvailableApps();
+      await availableReceived.future.timeout(const Duration(seconds: 5));
+      final pingsBefore = pingCount;
       await Future<void>.delayed(const Duration(milliseconds: 200));
 
       expect(

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -859,6 +859,7 @@ void main() {
         'has been hung for longer than the grace period', () async {
       final never = Completer<void>();
       final release = Completer<void>();
+      final categoriesReceived = Completer<void>();
       var pingCount = 0;
       server
         ..onMethod('core.ping', (_) {
@@ -870,6 +871,7 @@ void main() {
           return <Object>[];
         })
         ..onMethod('app.categories', (_) async {
+          categoriesReceived.complete();
           await release.future;
           return <String>[];
         });
@@ -883,11 +885,11 @@ void main() {
       expect(pingCount, greaterThan(0));
 
       // A newer request must hold keepalive off again for its own grace.
-      // Sample the baseline only after the request is in flight and any
-      // ping already on the wire has landed; otherwise a ping sent just
-      // before the request would be counted after the baseline was taken.
+      // Frames on one socket arrive in order, so once the server has seen
+      // this request, any ping sent before it has already been counted.
+      // Sampling the baseline earlier would miss such an in-flight ping.
       final pending = client.getAppCategories();
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await categoriesReceived.future.timeout(const Duration(seconds: 5));
       final pingsBefore = pingCount;
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(

--- a/test/services/truenas_api_client_test.dart
+++ b/test/services/truenas_api_client_test.dart
@@ -883,8 +883,12 @@ void main() {
       expect(pingCount, greaterThan(0));
 
       // A newer request must hold keepalive off again for its own grace.
-      final pingsBefore = pingCount;
+      // Sample the baseline only after the request is in flight and any
+      // ping already on the wire has landed; otherwise a ping sent just
+      // before the request would be counted after the baseline was taken.
       final pending = client.getAppCategories();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final pingsBefore = pingCount;
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(
         pingCount,


### PR DESCRIPTION
## Summary
- Fixes an intermittent failure in `truenas_api_client_test.dart` ("a newer request keeps its own grace window ..."), seen on main CI run 33985623855 (`Expected: <5>, Actual: <6>`).
- The test sampled the ping count and then started a new request. A keepalive ping already on the wire at that moment was counted after the baseline. The baseline is now taken once the request is in flight and any pending ping has landed, which is a stable point because no new pings are sent while a request is in flight.

## Test plan
- [x] Ran the affected test 10 times locally: 10/10 pass
- [x] Full `test/services/truenas_api_client_test.dart`: 50/50 pass
- [x] `flutter analyze` on the file: no issues

https://claude.ai/code/session_01DikQddgJ964DaX6sXpAKUC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved keepalive concurrency test synchronization to measure ping activity more reliably during the request grace period.
  - Replaced fixed-delay timing with event-based coordination and bounded timeouts, reducing the risk of flaky or inconsistent test results.
  - Ensured in-flight keepalive activity is included in baseline measurements before suppression behavior is verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->