### PR TITLE
fix: skip provisioning-profile lookup for the mac installer cert

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,7 +94,8 @@ lane :bootstrap_signing_mac do
   # installer that wraps it (mac_installer_distribution). Only the former
   # needs/gets a provisioning profile.
   match(type: "appstore", platform: "macos", readonly: false, api_key: api_key)
-  match(type: "mac_installer_distribution", platform: "macos", readonly: false, api_key: api_key)
+  match(type: "mac_installer_distribution", platform: "macos", readonly: false, api_key: api_key,
+        skip_provisioning_profiles: true)
 end
 
 # ---------------------------------------------------------------------------
@@ -168,8 +169,11 @@ private_lane :build_mac do
   sync_code_signing(type: "appstore", platform: "macos", readonly: is_ci, api_key: api_key)
   # Signs the .pkg installer that wraps the .app; setup_ci's temp keychain
   # holds exactly this one installer identity, so gym finds it without
-  # needing an explicit installer_cert_name.
-  sync_code_signing(type: "mac_installer_distribution", platform: "macos", readonly: is_ci, api_key: api_key)
+  # needing an explicit installer_cert_name. This cert type has no
+  # provisioning profile, so skip_provisioning_profiles avoids sigh
+  # searching for one that will never exist.
+  sync_code_signing(type: "mac_installer_distribution", platform: "macos", readonly: is_ci, api_key: api_key,
+                     skip_provisioning_profiles: true)
 
   # update_code_signing_settings below rewrites project.pbxproj on disk.
   # Restore it afterwards so a local build/beta leaves the tracked signing


### PR DESCRIPTION
## Summary
- Fixes the macOS TestFlight upload failure seen in the v0.6.0 release run (https://github.com/cedricziel/trueapp/actions/runs/33987466436): `match`/`sync_code_signing` for `type: "mac_installer_distribution"` was searching for a provisioning profile, but that cert type (which only signs the `.pkg` installer, not the app) never has one. In `readonly` mode on CI it can't create a placeholder either, so the step failed with "No matching provisioning profiles found ... cannot create a new one because you enabled `readonly`".
- Adds `skip_provisioning_profiles: true` to both `mac_installer_distribution` match calls (`bootstrap_signing_mac` and `build_mac`) so it only manages the certificate.

The iOS TestFlight upload for v0.6.0 succeeded fine; this only affects the new macOS lane added in #158.

## Test plan
- [x] `ruby -c fastlane/Fastfile` — syntax OK
- [ ] Next release-please release: macOS TestFlight upload step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Installation**
  * Updated macOS installer certificate synchronization to skip provisioning-profile handling during setup and builds.
  * Clarified that installer certificates do not require provisioning profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->