### PR TITLE
fix(ci): fetch the Mac installer cert via additional_cert_types

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -199,12 +199,13 @@ private_lane :build_mac do
   # Flutter's Runner target uses automatic signing, which needs an
   # interactive Apple ID session. Switch to manual signing with the profile
   # match just installed so xcodebuild can sign headlessly.
+  mac_profile = ENV["sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name"] || MAC_MATCH_PROFILE
   update_code_signing_settings(
     use_automatic_signing: false,
     path: MAC_XCODEPROJ,
     team_id: TEAM_ID,
     code_sign_identity: "Apple Distribution",
-    profile_name: ENV["sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name"] || MAC_MATCH_PROFILE,
+    profile_name: mac_profile,
     targets: [MAC_SCHEME]
   )
 
@@ -233,7 +234,7 @@ private_lane :build_mac do
     output_name: PKG_NAME,
     include_symbols: true,
     export_options: {
-      provisioningProfiles: { APP_IDENTIFIER => MAC_MATCH_PROFILE }
+      provisioningProfiles: { APP_IDENTIFIER => mac_profile }
     }
   )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,8 @@ MAC_XCODEPROJ   = "macos/Runner.xcodeproj"
 MAC_SCHEME      = "Runner"
 MAC_OUTPUT_DIR  = "build/macos"
 PKG_NAME        = "TrueNASManager"
+# match suffixes non-iOS profile names with the platform.
+MAC_MATCH_PROFILE = "#{MATCH_PROFILE} macos"
 
 # Build number = number of commits reachable from HEAD. Reproducible from git
 # state alone — never committed back to pubspec.yaml.
@@ -69,6 +71,11 @@ desc "Bootstrap signing — creates the App Store profile in the match repo. Run
 lane :bootstrap_signing do
   api_key = load_app_store_connect_api_key
   match(type: "appstore", readonly: false, api_key: api_key)
+end
+
+desc "Build a signed Mac App Store pkg without uploading (sanity check)"
+lane :build_pkg do
+  build_mac
 end
 
 desc "Build and push a new beta build to TestFlight (macOS)"
@@ -197,7 +204,7 @@ private_lane :build_mac do
     path: MAC_XCODEPROJ,
     team_id: TEAM_ID,
     code_sign_identity: "Apple Distribution",
-    profile_name: ENV["sigh_#{APP_IDENTIFIER}_appstore_profile-name"] || MATCH_PROFILE,
+    profile_name: ENV["sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name"] || MAC_MATCH_PROFILE,
     targets: [MAC_SCHEME]
   )
 
@@ -226,7 +233,7 @@ private_lane :build_mac do
     output_name: PKG_NAME,
     include_symbols: true,
     export_options: {
-      provisioningProfiles: { APP_IDENTIFIER => MATCH_PROFILE }
+      provisioningProfiles: { APP_IDENTIFIER => MAC_MATCH_PROFILE }
     }
   )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,10 +91,17 @@ lane :bootstrap_signing_mac do
   api_key = load_app_store_connect_api_key
   # Two certs are needed for a Mac App Store submission: one to sign the .app
   # (appstore, same cert type as iOS) and a separate one to sign the .pkg
-  # installer that wraps it (mac_installer_distribution). Only the former
-  # needs/gets a provisioning profile.
-  match(type: "appstore", platform: "macos", readonly: false, api_key: api_key)
-  match(type: "mac_installer_distribution", platform: "macos", readonly: false, api_key: api_key)
+  # installer that wraps it. The installer cert has no provisioning profile,
+  # so it must ride along via additional_cert_types: passing it as `type`
+  # makes match create a plain distribution cert and then fail looking for
+  # a profile that cannot exist.
+  match(
+    type: "appstore",
+    platform: "macos",
+    additional_cert_types: ["mac_installer_distribution"],
+    readonly: false,
+    api_key: api_key
+  )
 end
 
 # ---------------------------------------------------------------------------
@@ -165,11 +172,16 @@ end
 desc "match + Flutter build + xcodebuild archive for macOS. Returns the ASC API key."
 private_lane :build_mac do
   api_key = load_app_store_connect_api_key
-  sync_code_signing(type: "appstore", platform: "macos", readonly: is_ci, api_key: api_key)
-  # Signs the .pkg installer that wraps the .app; setup_ci's temp keychain
-  # holds exactly this one installer identity, so gym finds it without
-  # needing an explicit installer_cert_name.
-  sync_code_signing(type: "mac_installer_distribution", platform: "macos", readonly: is_ci, api_key: api_key)
+  # additional_cert_types also installs the installer cert that signs the
+  # .pkg; setup_ci's temp keychain then holds exactly one installer
+  # identity, so gym finds it without an explicit installer_cert_name.
+  sync_code_signing(
+    type: "appstore",
+    platform: "macos",
+    additional_cert_types: ["mac_installer_distribution"],
+    readonly: is_ci,
+    api_key: api_key
+  )
 
   # update_code_signing_settings below rewrites project.pbxproj on disk.
   # Restore it afterwards so a local build/beta leaves the tracked signing


### PR DESCRIPTION
## Summary
- The first `beta_mac` run (v0.6.0 release, run 33987466436) failed in match: `No matching provisioning profiles found for 'Unknown_com.cedricziel.trueapp.provisionprofile'`.
- Cause: `match(type: "mac_installer_distribution")` is not how fastlane expects the installer cert to be requested. With that as the primary type, `Match::Generator` calls `cert` with no specific type, so it created a plain Apple Distribution cert (8B3Z4CHZNU) instead of a `MAC_INSTALLER_DISTRIBUTION` one, and then tried to sync a profile for a type that has none.
- Fix: request the installer cert through `additional_cert_types: ["mac_installer_distribution"]` on the App Store macOS call, in both `bootstrap_signing_mac` and `build_mac`. That path passes the specific cert type through to `cert` and skips profile handling for it.

## Follow-up outside this PR
- [x] Done: the mis-typed cert and bogus profile were removed from the `certificates` match repo, then `bundle exec fastlane bootstrap_signing_mac` re-run once to create the real installer cert.
- [x] Done: cert 8B3Z4CHZNU revoked and the "match Unknown" profile deleted in the developer portal.

## Test plan
- [x] `ruby -c fastlane/Fastfile`
- [x] `bundle exec fastlane bootstrap_signing_mac` after the match repo cleanup (created MAC_INSTALLER_DISTRIBUTION cert 9P7BWJ7F5U)
- [x] `bundle exec fastlane build_pkg` locally: signed pkg produced, `pkgutil --check-signature` shows "3rd Party Mac Developer Installer"
- [ ] Upload path: next release run

https://claude.ai/code/session_01DikQddgJ964DaX6sXpAKUC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS signing configuration to support platform-specific provisioning profiles and distribution certificates.
  * Improved consistency when creating signed macOS builds and installer packages.
  * Added a package-build validation workflow for checking macOS installer artifacts before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
